### PR TITLE
[Feature] 이메일 발송 엔드포인트 남용 방지 - Rate Limiting 및 쿨다운 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,31 @@
 
 > 반응형 웹 디자인
 
-<img width="2912" height="1456" alt="Image" src="https://github.com/user-attachments/assets/76d1d906-1448-47aa-b4c3-039171b7d26c" />
+<img width="2912" alt="Image" src="https://github.com/user-attachments/assets/76d1d906-1448-47aa-b4c3-039171b7d26c" />
 
 > 사이드바 기능
 
-<img width="1858" height="1460" alt="Image" src="https://github.com/user-attachments/assets/b3f74286-ec31-4535-83f4-40396e185dbc" />
+<img width="1858" alt="Image" src="https://github.com/user-attachments/assets/b3f74286-ec31-4535-83f4-40396e185dbc" />
 
-<img width="2006" height="1400" alt="Image" src="https://github.com/user-attachments/assets/fb4f748a-113f-41f4-bffd-42af056350c1" />
+<img width="2006" alt="Image" src="https://github.com/user-attachments/assets/fb4f748a-113f-41f4-bffd-42af056350c1" />
 
 > 워크스페이스 설정 페이지
 
-<img width="3150" height="1772" alt="Image" src="https://github.com/user-attachments/assets/e378bb0f-d72f-4392-a124-e236bd460a43" />
+<img width="3150" alt="Image" src="https://github.com/user-attachments/assets/e378bb0f-d72f-4392-a124-e236bd460a43" />
 
 > 프로젝트 상세 조회 페이지 (칸반 보드)
 
-<img width="2528" height="1456" alt="Image" src="https://github.com/user-attachments/assets/8bec5540-82a2-44fc-a87f-b10a0cb3d0e8" />
+<img width="2528" alt="Image" src="https://github.com/user-attachments/assets/8bec5540-82a2-44fc-a87f-b10a0cb3d0e8" />
 
-<img width="2526" height="1596" alt="Image" src="https://github.com/user-attachments/assets/c7303c84-03a7-42bf-b1cb-3637f93a8e3e" />
+<img width="2526" alt="Image" src="https://github.com/user-attachments/assets/c7303c84-03a7-42bf-b1cb-3637f93a8e3e" />
 
 > 업무 상세 조회 페이지
 
-<img width="3024" height="1722" alt="Image" src="https://github.com/user-attachments/assets/3f686e1d-eb6e-4805-8338-8df85dd58b55" />
+<img width="3024" alt="Image" src="https://github.com/user-attachments/assets/3f686e1d-eb6e-4805-8338-8df85dd58b55" />
 
 > 스웨거 문서
 
-<img width="2146" height="3248" alt="Image" src="https://github.com/user-attachments/assets/cccff5cd-77f3-4734-8c47-641bf1fa8599" />
+<img width="2146" alt="Image" src="https://github.com/user-attachments/assets/cccff5cd-77f3-4734-8c47-641bf1fa8599" />
 
 ---
 
@@ -150,7 +150,7 @@ npm run dev
 
 ### 3.1. 아키텍처 다이어그램
 
-<img width="1594" height="1866" alt="Image" src="https://github.com/user-attachments/assets/85281081-1adf-412f-8ba6-fd80178ac5c5" />
+<img width="1594" alt="Image" src="https://github.com/user-attachments/assets/85281081-1adf-412f-8ba6-fd80178ac5c5" />
 
 - NGINX를 리버스 프록시로 설정하여, 리액트 정적 파일 서빙과 `/api/*` 백엔드 라우팅을 분리
 - Let's Encrypt + Certbot으로 SSL 인증서를 발급하여 NGINX 서버에 HTTPS를 적용
@@ -303,13 +303,17 @@ Let'z Collab은 세밀한 역할 기반 권한 제어(RBAC)를 통해 보안을 
 
 ---
 
-#### F. 비동기 이메일 서비스
+#### F. 비동기 이메일 서비스 및 남용 방지 (Rate Limiting)
 
 - `EmailContext` 인터페이스(`getTemplateName()`, `getSubject()`, `getVariables()`)를 전략 패턴으로 설계
     - `VerifyEmailContext`, `PasswordResetEmailContext` 등: 각 이메일 유형을 record로 작성하고 인터페이스를 `EmailContext` 구현
     - 새 이메일 유형 추가 시 서비스 코드 수정 없이 `EmailContext` 구현체만 추가하면 됨 → OCP 준수
 - `@Async` + `@Retryable` + `@TransactionalEventListener` 조합으로 비동기 처리 및 재시도 메커니즘 적용
     - 발송 실패 시 지수 백오프(2s → 4s)로 최대 3회 재시도, 전부 실패 시 `@Recover`에서 에러 로그 기록
+- 이메일 발송 엔드포인트 남용 방지를 NGINX와 Spring Boot 두 레이어에서 처리
+    - NGINX `limit_req_zone`으로 IP 기반 단기 차단 (인증 관련 1분당 1회 / 초대 1분당 10회)
+    - Spring Boot에서 DB 카운트 기반 장기 차단 (비밀번호 재설정 24시간당 3회, 워크스페이스 초대 초대자 기준 1시간당 50회)
+    - `AuthRateLimiter` / `InvitationRateLimiter` 인터페이스를 정의하고 `@Profile`로 구현체를 분리 — prod는 실제 제한, local/test는 `NoOp` 구현체로 제한 없이 동작
 
 ---
 
@@ -357,7 +361,7 @@ Let'z Collab은 세밀한 역할 기반 권한 제어(RBAC)를 통해 보안을 
 
 ## 4. ERD
 
-<img width="2138" height="2514" alt="Image" src="https://github.com/user-attachments/assets/6838449a-6db3-4dee-b4d8-4c50b20df050" />
+<img width="2138" alt="Image" src="https://github.com/user-attachments/assets/6838449a-6db3-4dee-b4d8-4c50b20df050" />
 
 ---
 
@@ -481,7 +485,7 @@ Let'z Collab은 세밀한 역할 기반 권한 제어(RBAC)를 통해 보안을 
 
 기존에는 이메일 발송을 서비스 레이어에서 동기적으로 직접 처리하여, SMTP 응답 지연이 API 응답 속도에 직접적인 영향을 미쳤습니다.
 
-<img width="2226" height="1260" alt="Image" src="https://github.com/user-attachments/assets/e4f6237f-a753-427a-885c-1092a1875de0" />
+<img width="2226" alt="Image" src="https://github.com/user-attachments/assets/e4f6237f-a753-427a-885c-1092a1875de0" />
 
 #### 개선 과정
 
@@ -497,7 +501,7 @@ Let'z Collab은 세밀한 역할 기반 권한 제어(RBAC)를 통해 보안을 
 
 #### 성능 개선 결과 (NCP vCPU 2코어, 10회 측정 기준)
 
-<img width="2234" height="1268" alt="Image" src="https://github.com/user-attachments/assets/b09f1516-6688-443d-82fb-f3f863632740" />
+<img width="2234" alt="Image" src="https://github.com/user-attachments/assets/b09f1516-6688-443d-82fb-f3f863632740" />
 
 | 측정 회차     | 동기 방식 (기존)   | 비동기 방식 (개선 후) |
 |:----------|:-------------|:--------------|
@@ -758,6 +762,13 @@ letzcollab/
             │   │   ├── DataInitializer.java          # 초기 시드 데이터 생성
             │   │   ├── JpaConfig.java
             │   │   └── QuerydslConfig.java
+            │   ├── ratelimit/                        # 이메일 발송 엔드포인트 남용 방지
+            │   │   ├── AuthRateLimiter.java
+            │   │   ├── InvitationRateLimiter.java
+            │   │   ├── NoOpAuthRateLimiter.java
+            │   │   ├── NoOpInvitationRateLimiter.java
+            │   │   ├── ProdAuthRateLimiter.java
+            │   │   └── ProdInvitationRateLimiter.java
             │   ├── scheduler/
             │   │   ├── NotificationCleanupScheduler.java     # 오래된 알림 정리
             │   │   └── TaskDeadlineScheduler.java            # 업무 마감 알림 발송

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/exception/ErrorCode.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/exception/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode {
 	VERIFICATION_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E002", "해당 인증 토큰을 찾을 수 없습니다."),
 	VERIFICATION_TOKEN_EXPIRED(HttpStatus.GONE, "E003", "인증 토큰이 만료되었습니다."),
 	VERIFICATION_TOKEN_ALREADY_USED(HttpStatus.GONE, "E004", "이미 사용된 인증 토큰입니다."),
+	EMAIL_SEND_TOO_FREQUENT(HttpStatus.TOO_MANY_REQUESTS, "E005", "이메일 발송 요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+	VERIFICATION_TOKEN_NOT_EXPIRED(HttpStatus.BAD_REQUEST, "E006", "아직 유효한 인증 토큰이 있습니다. 이메일을 확인해주세요."),
 
 	// --- Workspace (W) ---
 	// 보안을 위해, 권한 미달 때문에 실패했는지, 리소스가 없어서 실패했는지 정확히 알려주지 않음

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/AuthRateLimiter.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/AuthRateLimiter.java
@@ -1,0 +1,5 @@
+package xyz.letzcollab.backend.global.ratelimit;
+
+public interface AuthRateLimiter {
+	void rateLimitResetPwdReq(String email);
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/InvitationRateLimiter.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/InvitationRateLimiter.java
@@ -1,0 +1,7 @@
+package xyz.letzcollab.backend.global.ratelimit;
+
+import xyz.letzcollab.backend.entity.User;
+
+public interface InvitationRateLimiter {
+	void rateLimitInviteEmail(User inviter);
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/NoOpAuthRateLimiter.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/NoOpAuthRateLimiter.java
@@ -1,0 +1,11 @@
+package xyz.letzcollab.backend.global.ratelimit;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!prod")
+public class NoOpAuthRateLimiter implements AuthRateLimiter{
+	@Override
+	public void rateLimitResetPwdReq(String email) {}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/NoOpInvitationRateLimiter.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/NoOpInvitationRateLimiter.java
@@ -1,0 +1,15 @@
+package xyz.letzcollab.backend.global.ratelimit;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import xyz.letzcollab.backend.entity.User;
+import xyz.letzcollab.backend.entity.Workspace;
+
+import java.util.UUID;
+
+@Component
+@Profile("!prod")
+public class NoOpInvitationRateLimiter implements InvitationRateLimiter{
+	@Override
+	public void rateLimitInviteEmail(UUID userPublicId, UUID workspacePublicId, User inviter, Workspace workspace) {}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/ProdAuthRateLimiter.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/ProdAuthRateLimiter.java
@@ -1,0 +1,34 @@
+package xyz.letzcollab.backend.global.ratelimit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import xyz.letzcollab.backend.entity.vo.TokenType;
+import xyz.letzcollab.backend.global.exception.CustomException;
+import xyz.letzcollab.backend.global.exception.ErrorCode;
+import xyz.letzcollab.backend.repository.VerificationTokenRepository;
+
+import java.time.LocalDateTime;
+
+@Component
+@Profile("prod")
+@RequiredArgsConstructor
+@Slf4j
+public class ProdAuthRateLimiter implements AuthRateLimiter{
+
+	private final VerificationTokenRepository tokenRepository;
+
+	// 24시간에 3회 제한
+	@Override
+	public void rateLimitResetPwdReq(String email) {
+		long count = tokenRepository.countRecentByEmailAndType(
+				email, TokenType.PASSWORD_RESET, LocalDateTime.now().minusHours(24)
+		);
+
+		if (count >= 3) {
+			log.warn("비밀번호 재설정 요청 rate limit 초과 - email: {}", email);
+			throw new CustomException(ErrorCode.EMAIL_SEND_TOO_FREQUENT);
+		}
+	}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/ProdInvitationRateLimiter.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/ratelimit/ProdInvitationRateLimiter.java
@@ -1,0 +1,34 @@
+package xyz.letzcollab.backend.global.ratelimit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import xyz.letzcollab.backend.entity.User;
+import xyz.letzcollab.backend.entity.Workspace;
+import xyz.letzcollab.backend.global.exception.CustomException;
+import xyz.letzcollab.backend.global.exception.ErrorCode;
+import xyz.letzcollab.backend.repository.WorkspaceInvitationRepository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+@Profile("prod")
+@RequiredArgsConstructor
+@Slf4j
+public class ProdInvitationRateLimiter implements InvitationRateLimiter{
+
+	private final WorkspaceInvitationRepository invitationRepository;
+
+	// 1시간에 50개로 제한
+	@Override
+	public void rateLimitInviteEmail(User inviter) {
+		long count = invitationRepository.countByInviterAndCreatedAtAfter(inviter, LocalDateTime.now().minusHours(1));
+
+		if (count >= 50) {
+			log.warn("워크스페이스 초대 rate limit 초과 - inviterUserId={}", inviter.getPublicId());
+			throw new CustomException(ErrorCode.EMAIL_SEND_TOO_FREQUENT);
+		}
+	}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/VerificationTokenRepository.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/VerificationTokenRepository.java
@@ -1,11 +1,23 @@
 package xyz.letzcollab.backend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import xyz.letzcollab.backend.entity.VerificationToken;
+import xyz.letzcollab.backend.entity.vo.TokenType;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface VerificationTokenRepository extends JpaRepository<VerificationToken, Long> {
 	Optional<VerificationToken> findByToken(UUID token);
+
+	@Query("SELECT COUNT(t) FROM VerificationToken t " +
+			"WHERE t.user.email = :email AND t.type = :type AND t.createdAt > :since")
+	long countRecentByEmailAndType(
+			@Param("email") String email,
+			@Param("type") TokenType type,
+			@Param("since") LocalDateTime since
+	);
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/WorkspaceInvitationRepository.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/WorkspaceInvitationRepository.java
@@ -3,8 +3,10 @@ package xyz.letzcollab.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import xyz.letzcollab.backend.entity.User;
 import xyz.letzcollab.backend.entity.WorkspaceInvitation;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,4 +17,6 @@ public interface WorkspaceInvitationRepository extends JpaRepository<WorkspaceIn
 			"JOIN FETCH wi.workspace " +
 			"WHERE wi.token = :token")
 	Optional<WorkspaceInvitation> findByTokenWithWorkspace(@Param("token") UUID token);
+
+	long countByInviterAndCreatedAtAfter(User inviter, LocalDateTime since);
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/AuthService.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/AuthService.java
@@ -13,7 +13,6 @@ import xyz.letzcollab.backend.dto.auth.LoginResponse;
 import xyz.letzcollab.backend.dto.auth.SignupRequest;
 import xyz.letzcollab.backend.entity.User;
 import xyz.letzcollab.backend.entity.VerificationToken;
-import xyz.letzcollab.backend.entity.vo.TokenType;
 import xyz.letzcollab.backend.global.email.context.PasswordResetEmailContext;
 import xyz.letzcollab.backend.global.email.context.VerifyEmailContext;
 import xyz.letzcollab.backend.global.event.dto.EmailEvent;

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/AuthService.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/AuthService.java
@@ -13,16 +13,19 @@ import xyz.letzcollab.backend.dto.auth.LoginResponse;
 import xyz.letzcollab.backend.dto.auth.SignupRequest;
 import xyz.letzcollab.backend.entity.User;
 import xyz.letzcollab.backend.entity.VerificationToken;
+import xyz.letzcollab.backend.entity.vo.TokenType;
 import xyz.letzcollab.backend.global.email.context.PasswordResetEmailContext;
 import xyz.letzcollab.backend.global.email.context.VerifyEmailContext;
 import xyz.letzcollab.backend.global.event.dto.EmailEvent;
 import xyz.letzcollab.backend.global.exception.CustomException;
 import xyz.letzcollab.backend.global.exception.ErrorCode;
+import xyz.letzcollab.backend.global.ratelimit.AuthRateLimiter;
 import xyz.letzcollab.backend.global.security.jwt.JwtTokenProvider;
 import xyz.letzcollab.backend.global.security.userdetails.CustomUserDetails;
 import xyz.letzcollab.backend.repository.UserRepository;
 import xyz.letzcollab.backend.repository.VerificationTokenRepository;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -37,6 +40,7 @@ public class AuthService {
 	private final PasswordEncoder passwordEncoder;
 	private final AuthenticationManager authenticationManager;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final AuthRateLimiter authRateLimiter;
 
 	@Value("${frontend.base-url}")
 	private String frontendURL;
@@ -108,10 +112,7 @@ public class AuthService {
 																 return new CustomException(ErrorCode.VERIFICATION_TOKEN_NOT_FOUND);
 															 });
 
-		if (foundExpiredToken.getUsedAt() != null) {
-			log.warn("인증 메일 재발송 실패 - 이미 사용된 토큰: {}", expiredToken);
-			throw new CustomException(ErrorCode.VERIFICATION_TOKEN_ALREADY_USED);
-		}
+		verifyTokenExpirationAndUsage(expiredToken, foundExpiredToken);
 
 		User foundUser = foundExpiredToken.getUser();
 		VerificationToken newToken = VerificationToken.createEmailVerificationToken(foundUser);
@@ -137,6 +138,8 @@ public class AuthService {
 			throw new CustomException(ErrorCode.LOCKED);
 		}
 
+		authRateLimiter.rateLimitResetPwdReq(email);
+
 		VerificationToken passwordResetToken = VerificationToken.createPasswordVerificationToken(foundUser);
 		tokenRepository.save(passwordResetToken);
 
@@ -158,6 +161,8 @@ public class AuthService {
 		log.info("비밀번호 재설정 완료 - email: {}", foundToken.getUser().getEmail());
 	}
 
+
+	// 헬퍼
 	private VerificationToken getVerificationToken(UUID token) {
 		VerificationToken foundToken = tokenRepository.findByToken(token)
 													  .orElseThrow(() -> {
@@ -179,5 +184,14 @@ public class AuthService {
 	private void sendVerificationEmail(String name, String token, String email) {
 		VerifyEmailContext emailContext = new VerifyEmailContext(name, token, frontendURL);
 		eventPublisher.publishEvent(new EmailEvent(email, emailContext));
+	}
+
+	private void verifyTokenExpirationAndUsage(UUID expiredToken, VerificationToken foundExpiredToken) {
+		if (foundExpiredToken.getUsedAt() != null) {
+			log.warn("인증 메일 재발송 실패 - 이미 사용된 토큰: {}", expiredToken);
+			throw new CustomException(ErrorCode.VERIFICATION_TOKEN_ALREADY_USED);
+		} else if (foundExpiredToken.getExpiresAt().isAfter(LocalDateTime.now().plusMinutes(4))) {
+			throw new CustomException(ErrorCode.VERIFICATION_TOKEN_NOT_EXPIRED);
+		}
 	}
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/WorkspaceMemberService.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/WorkspaceMemberService.java
@@ -16,10 +16,12 @@ import xyz.letzcollab.backend.global.email.context.WorkspaceInvitationEmailConte
 import xyz.letzcollab.backend.global.event.dto.EmailEvent;
 import xyz.letzcollab.backend.global.exception.CustomException;
 import xyz.letzcollab.backend.global.exception.ErrorCode;
+import xyz.letzcollab.backend.global.ratelimit.InvitationRateLimiter;
 import xyz.letzcollab.backend.repository.UserRepository;
 import xyz.letzcollab.backend.repository.WorkspaceInvitationRepository;
 import xyz.letzcollab.backend.repository.WorkspaceMemberRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,6 +44,7 @@ public class WorkspaceMemberService {
 	private final WorkspaceMemberRepository memberRepository;
 	private final WorkspaceInvitationRepository invitationRepository;
 	private final UserRepository userRepository;
+	private final InvitationRateLimiter invitationRateLimiter;
 
 	@Value("${frontend.base-url}")
 	private String frontendURL;
@@ -54,6 +57,8 @@ public class WorkspaceMemberService {
 
 		User inviter = requester.getUser();
 		Workspace workspace = requester.getWorkspace();
+
+		invitationRateLimiter.rateLimitInviteEmail(inviter);
 
 		WorkspaceInvitation invitation = WorkspaceInvitation.createWorkspaceInvitation(inviter, workspace, inviteeEmail, inviteePosition);
 		invitationRepository.save(invitation);

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/WorkspaceMemberService.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/WorkspaceMemberService.java
@@ -21,7 +21,6 @@ import xyz.letzcollab.backend.repository.UserRepository;
 import xyz.letzcollab.backend.repository.WorkspaceInvitationRepository;
 import xyz.letzcollab.backend.repository.WorkspaceMemberRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 

--- a/letzcollab-frontend/src/components/workspace/InviteMemberModal.jsx
+++ b/letzcollab-frontend/src/components/workspace/InviteMemberModal.jsx
@@ -1,9 +1,11 @@
-import { Form, Input, message, Modal } from 'antd';
+import { Alert, Form, Input, message, Modal } from 'antd';
 import { useMutation } from '@tanstack/react-query';
 import api from '../../api/axios.js';
+import { useState } from "react";
 
 export default function InviteMemberModal({ open, workspacePublicId, onClose, onSuccess }) {
   const [form] = Form.useForm();
+  const [rateLimited, setRateLimited] = useState(false);
 
   const mutation = useMutation({
     mutationFn: (values) =>
@@ -16,7 +18,14 @@ export default function InviteMemberModal({ open, workspacePublicId, onClose, on
       form.resetFields();
       onSuccess?.();
     },
-    onError: (e) => message.error(e.response?.data?.message || '초대에 실패했습니다.'),
+    onError: (e) => {
+      const serverError = e.response?.data;
+      if (serverError.errorCode === 'E005') {
+        setRateLimited(true);
+      } else {
+        message.error(serverError?.message || '초대에 실패했습니다.');
+      }
+    }
   });
 
   const handleOk = async () => {
@@ -26,6 +35,7 @@ export default function InviteMemberModal({ open, workspacePublicId, onClose, on
 
   const handleCancel = () => {
     form.resetFields();
+    setRateLimited(false);
     onClose();
   };
 
@@ -38,8 +48,17 @@ export default function InviteMemberModal({ open, workspacePublicId, onClose, on
       okText="초대 이메일 발송"
       cancelText="취소"
       confirmLoading={mutation.isPending}
+      okButtonProps={{ disabled: rateLimited }}
     >
       <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+        {rateLimited && (
+          <Alert
+            type="warning"
+            title="초대 요청 횟수를 초과했습니다. 1시간 후에 다시 시도해주세요."
+            style={{ marginBottom: 16 }}
+            showIcon
+          />
+        )}
         <Form.Item
           name="email"
           label="이메일"

--- a/letzcollab-frontend/src/pages/RequestPasswordReset.jsx
+++ b/letzcollab-frontend/src/pages/RequestPasswordReset.jsx
@@ -1,14 +1,16 @@
-import { Form, Input, Button, Card, Typography, message, Flex } from "antd";
+import { Alert, Button, Card, Flex, Form, message, Typography } from "antd";
 import { ArrowLeftOutlined, MailOutlined } from '@ant-design/icons';
 import api from "../api/axios.js";
 import { useMutation } from "@tanstack/react-query";
 import AuthFormInput from "../components/AuthFormInput.jsx";
 import { Link } from "react-router-dom";
+import { useState } from "react";
 
 const { Title, Text } = Typography;
 
 export default function RequestPasswordReset() {
   const [form] = Form.useForm();
+  const [rateLimited, setRateLimited] = useState(false);
 
   const { mutate, isPending } = useMutation({
     mutationFn: async (values) => {
@@ -21,7 +23,11 @@ export default function RequestPasswordReset() {
     },
     onError: (error) => {
       const serverError = error.response?.data;
-      message.error(serverError?.message || '메일 발송 중 오류가 발생했습니다.');
+      if (serverError.errorCode === 'E005') {
+        setRateLimited(true);
+      } else {
+        message.error(serverError?.message || '메일 발송 중 오류가 발생했습니다.');
+      }
     }
   });
 
@@ -33,6 +39,14 @@ export default function RequestPasswordReset() {
           <Title level={3} style={{ marginBottom: 5 }}>비밀번호 재설정</Title>
           <Text type="secondary">가입하신 이메일 주소를 입력하시면 <br/>비밀번호 재설정 링크를 보내드립니다.</Text>
         </Flex>
+          {rateLimited && (
+            <Alert
+              type="warning"
+              title="요청 횟수를 초과했습니다. 24시간 후에 다시 시도해주세요."
+              style={{ marginBottom: 16 }}
+              showIcon
+            />
+          )}
         <Form form={form} requiredMark={false} layout="vertical" onFinish={(values) => mutate(values)}>
           <AuthFormInput
             name="email"
@@ -44,7 +58,7 @@ export default function RequestPasswordReset() {
             ]}
             placeholder="example@gmail.com"
           />
-          <Button htmlType="submit" block size="large" loading={isPending} color="default" variant="solid">
+          <Button htmlType="submit" block size="large" loading={isPending} color="default" variant="solid" disabled={rateLimited}>
             재설정 링크 전송
           </Button>
         </Form>

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,6 @@
+limit_req_zone $binary_remote_addr zone=email_auth:10m rate=1r/m;
+limit_req_zone $binary_remote_addr zone=email_invite:10m rate=10r/m;
+
 server {
     listen 80;
     server_name letzcollab.xyz www.letzcollab.xyz;
@@ -31,6 +34,28 @@ server {
     # 스프링 부트 백엔드
     location /api/ {
         proxy_pass http://letzcollab-backend:8080/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ ^/api/v1/auth/(signup|verify-email/resend|password/reset-request)$ {
+        limit_req zone=email_auth burst=2 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://letzcollab-backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ ^/api/v1/workspaces/[0-9a-f-]{36}/invitations$ {
+        limit_req zone=email_invite burst=10 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://letzcollab-backend:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 📝 요약 (Summary)

이메일 발송 엔드포인트(회원가입 인증, 비밀번호 재설정, 워크스페이스 초대)에 대한 남용 방지 처리를 추가한다.
NGINX 단의 IP 기반 단기 차단과 Spring Boot 애플리케이션 단의 DB 기반 장기 차단을 조합하여 두 레이어에서 방어한다.

- 이슈 #21

## 🛠️ 작업 내용 (Details)

**NGINX (`nginx.conf`)**
- `email_auth` zone (1분당 1회, burst 2) — 인증 관련 3개 엔드포인트를 정규식으로 묶어 하나의 `location` 블록에 적용
- `email_invite` zone (1분당 10회, burst 10) — 워크스페이스 초대 엔드포인트에 적용

**Spring Boot**
- `global/ratelimit/` 패키지 신설
  - `AuthRateLimiter` / `InvitationRateLimiter` 인터페이스 정의
  - `@Profile("prod")` — `ProdAuthRateLimiter` (비밀번호 재설정 24시간 3회), `ProdInvitationRateLimiter` (초대 1시간 50회)
  - `@Profile("!prod")` — `NoOpAuthRateLimiter`, `NoOpInvitationRateLimiter` (제한 없음)
- `VerificationTokenRepository` — `countRecentByEmailAndType()` 추가 (이메일 + 토큰 타입 + 기간 기준 카운트 JPQL)
- `WorkspaceInvitationRepository` — `countByInviterAndCreatedAtAfter()` 추가 (Spring Data JPA 메서드)
- `AuthService`
  - `requestResetPassword()` — 24시간 내 3회 초과 시 `EMAIL_SEND_TOO_FREQUENT`
  - `resendVerificationEmail()` — 아직 유효한 토큰으로 재발송 요청 시 `VERIFICATION_TOKEN_NOT_EXPIRED`
- `WorkspaceMemberService` — `inviteMemberByEmail()` 메소드를 1시간 내 50회 호출 초과 시 `EMAIL_SEND_TOO_FREQUENT`
- `ErrorCode` — `EMAIL_SEND_TOO_FREQUENT` (E005, 429), `VERIFICATION_TOKEN_NOT_EXPIRED` (E006, 400) 추가

**프론트엔드**
- `RequestPasswordReset.jsx` — E005 에러코드 응답 수신 시 `Alert` 표시 및 제출 버튼 비활성화
- `InviteMemberModal.jsx` — E005 에러코드 응답 수신 시 `Alert` 표시 및 확인 버튼 비활성화, 모달 닫을 때 상태 초기화

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)

## 🧪 테스트 방법 (Testing)

**NGINX**
- 동일 IP에서 인증 관련 엔드포인트를 1분 내 3회 이상 호출 → 429 응답 확인

**Spring Boot — prod 프로파일**
- `POST /v1/auth/password/reset-request` 동일 이메일로 24시간 내 4회 호출 → 4번째 요청에서 `E005` 응답 확인
- `POST /v1/workspaces/{id}/invitations` 1시간 내 51회 호출 → 51번째 요청에서 `E005` 응답 확인
- 유효한(미만료) 토큰으로 `POST /v1/auth/verify-email/resend` 호출 → `E006` 응답 확인

**프론트엔드**
- 비밀번호 재설정 페이지에서 E005 에러코드 응답 수신 시 Alert 노출 및 버튼 비활성화 확인
- 워크스페이스 초대 모달에서 E005 에러코드 응답 수신 시 Alert 노출 및 확인 버튼 비활성화 확인
