### PR TITLE
[Feature] 갱신 토큰 기능 구현

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,6 +9,11 @@ services:
       POSTGRES_DB: ${DB_NAME}
     volumes:
       - ./postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - letzcollab-net
 
@@ -17,10 +22,21 @@ services:
     container_name: letzcollab-backend
     restart: always
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     env_file:
       # secrets.ENV_FILE
       - .env
+    networks:
+      - letzcollab-net
+
+  redis:
+    image: redis:7-alpine
+    container_name: letzcollab-redis
+    restart: always
+    command: redis-server --requirepass ${REDIS_PASSWORD}
     networks:
       - letzcollab-net
 

--- a/letzcollab-backend/build.gradle
+++ b/letzcollab-backend/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // 이메일
     implementation 'org.springframework.boot:spring-boot-starter-mail'
@@ -65,6 +66,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'com.redis:testcontainers-redis:2.2.4'
 }
 
 // QClass 생성 경로 설정

--- a/letzcollab-backend/docker-compose.yml
+++ b/letzcollab-backend/docker-compose.yml
@@ -11,6 +11,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     command: ["postgres", "-c", "shared_buffers=512MB"]
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     deploy:
       resources:
         limits:
@@ -34,7 +39,10 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     environment:
       - JAVA_OPTS=-Xms512m -Xmx512m  # JVM 힙 메모리 제한
       - SPRING_DATASOURCE_URL=jdbc:postgresql://letzcollab-db:5432/letzcollab_db
@@ -45,6 +53,17 @@ services:
         limits:
           cpus: '2'
           memory: 1G
+
+  redis:
+    image: redis:7-alpine
+    container_name: letzcollab-redis
+    ports:
+      - "6379:6379"
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
 
   prometheus:
     image: prom/prometheus:latest

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/controller/AuthController.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/controller/AuthController.java
@@ -4,14 +4,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import xyz.letzcollab.backend.dto.auth.*;
 import xyz.letzcollab.backend.global.dto.ApiResponse;
+import xyz.letzcollab.backend.global.security.userdetails.CustomUserDetails;
 import xyz.letzcollab.backend.service.AuthService;
 
 import java.net.URI;
@@ -21,11 +22,17 @@ import java.net.URI;
 @RequestMapping("/v1/auth")
 public class AuthController {
 	private final AuthService authService;
-	private final boolean cookieSecure;
+	private final long jwtAccessValidityInMs;
+	private final long jwtRefreshValidityInDays;
 
-	public AuthController(AuthService authService, @Value("${cookie.secure}") boolean cookieSecure) {
+	public AuthController(
+			AuthService authService,
+			@Value("${jwt.access-validity-in-ms}") long jwtAccessValidityInMs,
+			@Value("${jwt.refresh-validity-in-days}") long jwtRefreshValidityInDays
+	) {
 		this.authService = authService;
-		this.cookieSecure = cookieSecure;
+		this.jwtAccessValidityInMs = jwtAccessValidityInMs;
+		this.jwtRefreshValidityInDays = jwtRefreshValidityInDays;
 	}
 
 	@Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다. 30분 이내에 이메일 인증을 완료해야 로그인이 가능합니다.")
@@ -50,16 +57,7 @@ public class AuthController {
 
 		// 1. 웹 브라우저인 경우 JWT를 쿠키로만 전송
 		if ("web".equalsIgnoreCase(clientType)) {
-			ResponseCookie cookie = ResponseCookie.from("accessToken", loginResponse.accessToken())
-												  .httpOnly(true)	// XSS 방지(JS에서 접근 불가)
-												  .secure(cookieSecure)
-												  .path("/")
-												  .maxAge(60 * 30)
-												  .sameSite("Lax")	// CSRF 방지
-												  .build();
-
-			httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-
+			setCookies(httpServletResponse, loginResponse.accessToken(), loginResponse.refreshToken());
 			return ResponseEntity.ok(ApiResponse.success(loginResponse.withoutToken(), "로그인 성공!"));
 		}
 
@@ -67,24 +65,47 @@ public class AuthController {
 		return ResponseEntity.ok(ApiResponse.success(loginResponse, "로그인 성공!"));
 	}
 
-	/**
-	 *
-	 * (웹 프론트 전용)
-	 * 브라우저에서 JWT 쿠키를 없애고 싶을 때 호출
-	 */
-	@Operation(summary = "로그아웃", description = "웹 브라우저의 JWT 쿠키를 만료시켜 로그아웃 처리합니다.")
+	@Operation(
+			summary = "JWT 재발급",
+			description = "JWT와 갱신 토큰을 새로 발급합니다.<br>웹 프론트엔드는 `X-Client-Type: web` 헤더 전송 시 HttpOnly 쿠키가 자동 세팅됩니다."
+	)
+	@PostMapping("/refresh")
+	public ResponseEntity<ApiResponse<RefreshResponse>> refresh(
+			@RequestBody(required = false) RefreshRequest req,
+			@CookieValue(name = "refreshToken", required = false) String refreshToken,
+			@RequestHeader(value = "X-Client-Type", defaultValue = "web") String clientType,
+			HttpServletResponse httpServletResponse
+	) {
+		RefreshResponse res;
+
+		if ("web".equalsIgnoreCase(clientType)) {
+			res = authService.refresh(refreshToken);
+			setCookies(httpServletResponse, res.accessToken(), res.refreshToken());
+			return ResponseEntity.ok(ApiResponse.success(res.withoutToken(), "JWT 재발급 성공!"));
+		}
+
+		res = authService.refresh(req.refreshToken());
+		return ResponseEntity.ok(ApiResponse.success(res, "JWT 재발급 성공!"));
+	}
+
+	@Operation(summary = "로그아웃", description = "웹 브라우저인 경우 JWT/갱신 토큰 쿠키를 만료시키고, 모바일인 경우 갱신 토큰을 redis에서 제거하여 로그아웃 처리합니다.")
 	@PostMapping("/logout")
-	public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse httpServletResponse) {
+	public ResponseEntity<ApiResponse<Void>> logout(
+			@AuthenticationPrincipal CustomUserDetails userDetails,
+			@RequestBody(required = false) LogoutRequest req,
+			@CookieValue(name = "refreshToken", required = false) String refreshToken,
+			@RequestHeader(value = "X-Client-Type", defaultValue = "web") String clientType,
+			HttpServletResponse httpServletResponse
+	) {
+		String userEmail = userDetails.getEmail();
 
-		ResponseCookie cookie = ResponseCookie.from("accessToken", "")
-											  .httpOnly(true)
-											  .secure(cookieSecure)
-											  .path("/")
-											  .maxAge(0)
-											  .sameSite("Lax")
-											  .build();
+		if ("web".equalsIgnoreCase(clientType)) {
+			authService.logout(refreshToken, userEmail);
+			removeCookies(httpServletResponse);
+		} else {
+			authService.logout(req.refreshToken(), userEmail);
+		}
 
-		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 		return ResponseEntity.ok(ApiResponse.success("로그아웃 성공!"));
 	}
 
@@ -116,5 +137,32 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<Void>> resetPassword(@Valid @RequestBody PasswordResetRequest req) {
 		authService.resetPassword(req.token(), req.newPassword());
 		return ResponseEntity.ok(ApiResponse.success("비밀번호 초기화 성공!"));
+	}
+
+
+	// 헬퍼
+	private ResponseCookie getTokenCookie(boolean isAccessToken, String cookieVal, long maxAge) {
+		String cookieName = isAccessToken ? "accessToken" : "refreshToken";
+
+		return ResponseCookie.from(cookieName, cookieVal)
+							 .httpOnly(true)    // XSS 방지(JS에서 접근 불가)
+							 .path("/")
+							 .maxAge(maxAge)
+							 .sameSite("Lax")    // CSRF 방지 (같은 사이트 + 외부에서 링크 클릭으로 이동만 허용)
+							 .build();
+	}
+
+	private void setCookies(HttpServletResponse httpServletResponse, String accessToken, String refreshToken) {
+		ResponseCookie accessTokenCookie = getTokenCookie(true, accessToken, jwtAccessValidityInMs/1000);
+		ResponseCookie refreshTokenCookie = getTokenCookie(false, refreshToken, jwtRefreshValidityInDays * 86400);
+		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+	}
+
+	private void removeCookies(HttpServletResponse httpServletResponse) {
+		ResponseCookie accessTokenCookie = getTokenCookie(true, "", 0);
+		ResponseCookie refreshTokenCookie = getTokenCookie(false, "", 0);
+		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 	}
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/LoginResponse.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/LoginResponse.java
@@ -9,6 +9,9 @@ public record LoginResponse(
 	@Schema(description = "발급된 JWT 액세스 토큰 (모바일용. 웹일 경우 null)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 	String accessToken,
 
+	@Schema(description = "발급된 갱신 토큰 (모바일용. 웹일 경우 null)", example = "tVToUCQ93PR_CAUx4lJxhq7r...")
+	String refreshToken,
+
 	@Schema(description = "사용자 이름", example = "홍길동")
 	String name,
 
@@ -16,6 +19,6 @@ public record LoginResponse(
 	String email
 ) {
 	public LoginResponse withoutToken() {
-		return new LoginResponse(null, this.name, this.email);
+		return new LoginResponse(null, null, this.name, this.email);
 	}
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/LogoutRequest.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/LogoutRequest.java
@@ -1,0 +1,10 @@
+package xyz.letzcollab.backend.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그아웃 요청 DTO")
+public record LogoutRequest(
+	@Schema(description = "유효한 갱신 토큰", example = "tVToUCQ93PR_CAUx4lJxhq7r...")
+	String refreshToken
+) {
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/RefreshRequest.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/RefreshRequest.java
@@ -1,0 +1,10 @@
+package xyz.letzcollab.backend.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "JWT 재발급 요청 DTO")
+public record RefreshRequest(
+	@Schema(description = "갱신 토큰", example = "tVToUCQ93PR_CAUx4lJxhq7r...")
+	String refreshToken
+) {
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/RefreshResponse.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/RefreshResponse.java
@@ -1,0 +1,18 @@
+package xyz.letzcollab.backend.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "토큰 재발급 응답 DTO")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RefreshResponse(
+	@Schema(description = "새로 발급된 JWT 액세스 토큰 (모바일용. 웹일 경우 null)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String accessToken,
+
+	@Schema(description = "새로 발급된 갱신 토큰 (모바일용. 웹일 경우 null)", example = "tVToUCQ93PR_CAUx4lJxhq7r...")
+	String refreshToken
+) {
+	public RefreshResponse withoutToken() {
+		return new RefreshResponse(null, null);
+	}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/RefreshTokenData.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/auth/RefreshTokenData.java
@@ -1,0 +1,13 @@
+package xyz.letzcollab.backend.dto.auth;
+
+import xyz.letzcollab.backend.global.security.userdetails.CustomUserDetails;
+
+public record RefreshTokenData(String publicId, String email, String role) {
+	public static RefreshTokenData from(CustomUserDetails userDetails) {
+		return new RefreshTokenData(
+				userDetails.getPublicId().toString(),
+				userDetails.getEmail(),
+				userDetails.getRole().getAuthority()
+		);
+	}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/exception/ErrorCode.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 	DISABLED(HttpStatus.FORBIDDEN, "A005", "이메일 인증을 먼저 완료해주세요."),
 	LOCKED(HttpStatus.FORBIDDEN, "A006", "탈퇴했거나 차단된 계정입니다."),
 	BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A007", "이메일 또는 비밀번호가 잘못되었습니다"),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A008", "유효하지 않은 갱신 토큰입니다."),
 
 	// --- User (U) ---
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 사용자입니다."),
@@ -72,7 +73,10 @@ public enum ErrorCode {
 	COMMENT_REPLY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "TC003", "대댓글에는 답글을 달 수 없습니다."),
 
 	// --- Notification (N) ---
-	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "알림을 찾을 수 없습니다.");
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "알림을 찾을 수 없습니다."),
+
+	// --- Dao (D) ---
+	DAO_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "D001", "일시적인 저장소 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/exception/GlobalExceptionHandler.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package xyz.letzcollab.backend.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -77,6 +78,14 @@ public class GlobalExceptionHandler {
 		log.warn("메소드 인자 타입 불일치: {} - {}", e.getName(), e.getValue());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 							 .body(ApiResponse.fail(ErrorCode.INVALID_TYPE_VALUE));
+	}
+
+	// DB/Redis 서버 연결 실패 또는 타임아웃
+	@ExceptionHandler(DataAccessException.class)
+	public ResponseEntity<ApiResponse<Void>> handleDataAccessException(DataAccessException e) {
+		log.error("데이터 저장소 오류 발생: {}", e.getMessage(), e);
+		return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+							 .body(ApiResponse.fail(ErrorCode.DAO_ERROR));
 	}
 
 	// 그 외 예상치 못한 모든 예외

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/security/jwt/JwtTokenProvider.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/security/jwt/JwtTokenProvider.java
@@ -9,6 +9,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
+import xyz.letzcollab.backend.dto.auth.RefreshTokenData;
 import xyz.letzcollab.backend.entity.vo.UserRole;
 import xyz.letzcollab.backend.global.security.userdetails.CustomUserDetails;
 
@@ -45,6 +46,20 @@ public class JwtTokenProvider {
 				   .subject(publicId)
 				   .claim("email", email)
 				   .claim("role", role)
+				   .issuedAt(now)
+				   .expiration(expiryDate)
+				   .signWith(key)
+				   .compact();
+	}
+
+	public String createToken(RefreshTokenData data) {
+		Date now = new Date();
+		Date expiryDate = new Date(now.getTime() + accessTokenValidityInMs);
+
+		return Jwts.builder()
+				   .subject(data.publicId())
+				   .claim("email", data.email())
+				   .claim("role", data.role())
 				   .issuedAt(now)
 				   .expiration(expiryDate)
 				   .signWith(key)

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/security/jwt/RefreshTokenProvider.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/global/security/jwt/RefreshTokenProvider.java
@@ -1,0 +1,21 @@
+package xyz.letzcollab.backend.global.security.jwt;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class RefreshTokenProvider {
+	private final SecureRandom secureRandom;
+
+	public RefreshTokenProvider() {
+		this.secureRandom = new SecureRandom();
+	}
+
+	public String createToken() {
+		byte[] randomBytes = new byte[32];
+		secureRandom.nextBytes(randomBytes);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+	}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/redis/RefreshTokenRepository.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/redis/RefreshTokenRepository.java
@@ -1,0 +1,63 @@
+package xyz.letzcollab.backend.repository.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import xyz.letzcollab.backend.dto.auth.RefreshTokenData;
+import xyz.letzcollab.backend.global.exception.CustomException;
+
+import java.util.concurrent.TimeUnit;
+
+import static xyz.letzcollab.backend.global.exception.ErrorCode.DAO_ERROR;
+
+@Repository
+@Slf4j
+public class RefreshTokenRepository {
+	private static final String REFRESH_TOKEN_PREFIX = "RT:";
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final long rtValidityInDays;
+	private final ObjectMapper objectMapper;
+
+	public RefreshTokenRepository(
+			RedisTemplate<String, String> redisTemplate,
+			@Value("${jwt.refresh-validity-in-days}") long rtValidityInDays,
+			ObjectMapper objectMapper
+	) {
+		this.redisTemplate = redisTemplate;
+		this.rtValidityInDays = rtValidityInDays;
+		this.objectMapper = objectMapper;
+	}
+
+	public void saveRefreshToken(String token, RefreshTokenData data) {
+		try {
+			String redisKey = REFRESH_TOKEN_PREFIX + token;
+			String json = objectMapper.writeValueAsString(data);
+			redisTemplate.opsForValue().set(redisKey, json, rtValidityInDays, TimeUnit.DAYS);
+		} catch (JsonProcessingException e) {
+			log.error("갱신 토큰 redis 값 직렬화 실패: {}", e.getMessage());
+			throw new CustomException(DAO_ERROR);
+		}
+	}
+
+	public RefreshTokenData getRefreshTokenData(String token) {
+		try {
+			String redisKey = REFRESH_TOKEN_PREFIX + token;
+			String json = redisTemplate.opsForValue().get(redisKey);
+
+			if (json == null) return null;
+			return objectMapper.readValue(json, RefreshTokenData.class);
+		} catch (JsonProcessingException e) {
+			log.error("갱신 토큰 역직렬화 실패: {}", e.getMessage());
+			throw new CustomException(DAO_ERROR);
+		}
+	}
+
+	public boolean deleteRefreshToken(String token) {
+		String redisKey = REFRESH_TOKEN_PREFIX + token;
+		return Boolean.TRUE.equals(redisTemplate.delete(redisKey));
+	}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/AuthService.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/AuthService.java
@@ -10,6 +10,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.letzcollab.backend.dto.auth.LoginResponse;
+import xyz.letzcollab.backend.dto.auth.RefreshResponse;
+import xyz.letzcollab.backend.dto.auth.RefreshTokenData;
 import xyz.letzcollab.backend.dto.auth.SignupRequest;
 import xyz.letzcollab.backend.entity.User;
 import xyz.letzcollab.backend.entity.VerificationToken;
@@ -17,15 +19,18 @@ import xyz.letzcollab.backend.global.email.context.PasswordResetEmailContext;
 import xyz.letzcollab.backend.global.email.context.VerifyEmailContext;
 import xyz.letzcollab.backend.global.event.dto.EmailEvent;
 import xyz.letzcollab.backend.global.exception.CustomException;
-import xyz.letzcollab.backend.global.exception.ErrorCode;
 import xyz.letzcollab.backend.global.ratelimit.AuthRateLimiter;
 import xyz.letzcollab.backend.global.security.jwt.JwtTokenProvider;
+import xyz.letzcollab.backend.global.security.jwt.RefreshTokenProvider;
 import xyz.letzcollab.backend.global.security.userdetails.CustomUserDetails;
 import xyz.letzcollab.backend.repository.UserRepository;
 import xyz.letzcollab.backend.repository.VerificationTokenRepository;
+import xyz.letzcollab.backend.repository.redis.RefreshTokenRepository;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+
+import static xyz.letzcollab.backend.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +44,8 @@ public class AuthService {
 	private final PasswordEncoder passwordEncoder;
 	private final AuthenticationManager authenticationManager;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final RefreshTokenProvider refreshTokenProvider;
 	private final AuthRateLimiter authRateLimiter;
 
 	@Value("${frontend.base-url}")
@@ -47,7 +54,7 @@ public class AuthService {
 	public void signup(SignupRequest req) {
 		if (userRepository.existsByEmail(req.email())) {
 			log.warn("회원가입 실패 - 이메일 중복: {}", req.email());
-			throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+			throw new CustomException(DUPLICATE_EMAIL);
 		}
 
 		User user = User.createPendingUser(
@@ -74,11 +81,14 @@ public class AuthService {
 
 			Authentication authentication = authenticationManager.authenticate(authenticationToken);
 
-			String token = jwtTokenProvider.createToken(authentication);
+			String accessToken = jwtTokenProvider.createToken(authentication);
+			String refreshToken = refreshTokenProvider.createToken();
+
 			CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+			refreshTokenRepository.saveRefreshToken(refreshToken, RefreshTokenData.from(userDetails));
 
 			log.info("로그인 성공 - email: {}", email);
-			return new LoginResponse(token, userDetails.getName(), userDetails.getEmail());
+			return new LoginResponse(accessToken, refreshToken, userDetails.getName(), userDetails.getEmail());
 
 		} catch (BadCredentialsException e) {
 			log.warn("로그인 실패 - 이메일 또는 비밀번호 불일치: {}", email);
@@ -89,6 +99,37 @@ public class AuthService {
 		} catch (LockedException e) {
 			log.warn("로그인 실패 - 계정 잠김/탈퇴: {}", email);
 			throw e;
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public RefreshResponse refresh(String oldRefreshToken) {
+		RefreshTokenData data = refreshTokenRepository.getRefreshTokenData(oldRefreshToken);
+
+		if (data == null) {
+			throw new CustomException(INVALID_REFRESH_TOKEN);
+		}
+
+		log.debug("JWT 재발급 시도 - email: {}", data.email());
+
+		String newAccessToken = jwtTokenProvider.createToken(data);
+		String newRefreshToken = refreshTokenProvider.createToken();
+
+		refreshTokenRepository.saveRefreshToken(newRefreshToken, data);
+		refreshTokenRepository.deleteRefreshToken(oldRefreshToken);
+
+		log.info("JWT 재발급 성공 - email: {}", data.email());
+		return new RefreshResponse(newAccessToken, newRefreshToken);
+	}
+
+	@Transactional(readOnly = true)
+	public void logout(String oldRefreshToken, String email) {
+		boolean deleted = refreshTokenRepository.deleteRefreshToken(oldRefreshToken);
+
+		if (deleted) {
+			log.info("로그아웃 성공 - email: {}", email);
+		} else {
+			log.info("갱신 토큰 제거 실패 - email: {}", email);
 		}
 	}
 
@@ -108,7 +149,7 @@ public class AuthService {
 		VerificationToken foundExpiredToken = tokenRepository.findByToken(expiredToken)
 															 .orElseThrow(() -> {
 																 log.warn("인증 메일 재발송 실패 - 토큰 없음: {}", expiredToken);
-																 return new CustomException(ErrorCode.VERIFICATION_TOKEN_NOT_FOUND);
+																 return new CustomException(VERIFICATION_TOKEN_NOT_FOUND);
 															 });
 
 		verifyTokenExpirationAndUsage(expiredToken, foundExpiredToken);
@@ -129,12 +170,12 @@ public class AuthService {
 		User foundUser = userRepository.findByEmail(email)
 									   .orElseThrow(() -> {
 										   log.warn("비밀번호 재설정 실패 - 존재하지 않는 이메일: {}", email);
-										   return new CustomException(ErrorCode.USER_NOT_FOUND);
+										   return new CustomException(USER_NOT_FOUND);
 									   });
 
 		if (!foundUser.getStatus().canResetPassword()) {
 			log.warn("비밀번호 재설정 실패 - 정지 또는 탈퇴 계정: {}", email);
-			throw new CustomException(ErrorCode.LOCKED);
+			throw new CustomException(LOCKED);
 		}
 
 		authRateLimiter.rateLimitResetPwdReq(email);
@@ -166,16 +207,16 @@ public class AuthService {
 		VerificationToken foundToken = tokenRepository.findByToken(token)
 													  .orElseThrow(() -> {
 														  log.warn("토큰 조회 실패 - 존재하지 않는 토큰: {}", token);
-														  return new CustomException(ErrorCode.VERIFICATION_TOKEN_NOT_FOUND);
+														  return new CustomException(VERIFICATION_TOKEN_NOT_FOUND);
 													  });
 
 		if (foundToken.getUsedAt() != null) {
 			log.warn("토큰 검증 실패 - 이미 사용된 토큰: {}", token);
-			throw new CustomException(ErrorCode.VERIFICATION_TOKEN_ALREADY_USED);
+			throw new CustomException(VERIFICATION_TOKEN_ALREADY_USED);
 		}
 		if (foundToken.isExpired()) {
 			log.warn("토큰 검증 실패 - 만료된 토큰: {}", token);
-			throw new CustomException(ErrorCode.VERIFICATION_TOKEN_EXPIRED);
+			throw new CustomException(VERIFICATION_TOKEN_EXPIRED);
 		}
 		return foundToken;
 	}
@@ -188,9 +229,9 @@ public class AuthService {
 	private void verifyTokenExpirationAndUsage(UUID expiredToken, VerificationToken foundExpiredToken) {
 		if (foundExpiredToken.getUsedAt() != null) {
 			log.warn("인증 메일 재발송 실패 - 이미 사용된 토큰: {}", expiredToken);
-			throw new CustomException(ErrorCode.VERIFICATION_TOKEN_ALREADY_USED);
+			throw new CustomException(VERIFICATION_TOKEN_ALREADY_USED);
 		} else if (foundExpiredToken.getExpiresAt().isAfter(LocalDateTime.now().plusMinutes(4))) {
-			throw new CustomException(ErrorCode.VERIFICATION_TOKEN_NOT_EXPIRED);
+			throw new CustomException(VERIFICATION_TOKEN_NOT_EXPIRED);
 		}
 	}
 }

--- a/letzcollab-backend/src/main/resources/application-local.yml
+++ b/letzcollab-backend/src/main/resources/application-local.yml
@@ -26,8 +26,10 @@ spring:
       mail:
         debug: true
 
-cookie:
-  secure: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 management:
   endpoints:

--- a/letzcollab-backend/src/main/resources/application-prod.yml
+++ b/letzcollab-backend/src/main/resources/application-prod.yml
@@ -26,9 +26,11 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
+  data:
+    redis:
+      host: letzcollab-redis
+      port: 6379
+      password: ${REDIS_PASSWORD}
 
 frontend:
   base-url: https://letzcollab.xyz
-
-cookie:
-  secure: true

--- a/letzcollab-backend/src/main/resources/application.yml
+++ b/letzcollab-backend/src/main/resources/application.yml
@@ -32,6 +32,7 @@ frontend:
 jwt:
   secret: ${JWT_ENC_KEY}
   access-validity-in-ms: ${JWT_ACCESS_EXP_TIME}
+  refresh-validity-in-days: ${JWT_REFRESH_EXP_TIME}
 
 springdoc:
   swagger-ui:

--- a/letzcollab-backend/src/test/java/xyz/letzcollab/backend/repository/redis/RefreshTokenRepositoryTest.java
+++ b/letzcollab-backend/src/test/java/xyz/letzcollab/backend/repository/redis/RefreshTokenRepositoryTest.java
@@ -1,0 +1,99 @@
+package xyz.letzcollab.backend.repository.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import xyz.letzcollab.backend.dto.auth.RefreshTokenData;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@DisplayName("RefreshTokenRepository 단위 테스트")
+class RefreshTokenRepositoryTest {
+
+	@Container
+	private static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@BeforeEach
+	void setUp() {
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(
+				redis.getHost(),
+				redis.getFirstMappedPort()
+		);
+		LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+		factory.afterPropertiesSet();
+
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(factory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.afterPropertiesSet();
+
+		refreshTokenRepository = new RefreshTokenRepository(redisTemplate, 14L, new ObjectMapper());
+	}
+
+	private RefreshTokenData createTokenData() {
+		return new RefreshTokenData(
+				UUID.randomUUID().toString(),
+				"test@example.com",
+				"ROLE_USER"
+		);
+	}
+
+	@Test
+	@DisplayName("저장한 갱신 토큰을 올바르게 조회할 수 있다")
+	void saveAndGet_success() {
+		// given
+		String token = "test-token";
+		RefreshTokenData data = createTokenData();
+
+		// when
+		refreshTokenRepository.saveRefreshToken(token, data);
+		RefreshTokenData found = refreshTokenRepository.getRefreshTokenData(token);
+
+		// then
+		assertThat(found).isNotNull();
+		assertThat(found.publicId()).isEqualTo(data.publicId());
+		assertThat(found.email()).isEqualTo(data.email());
+		assertThat(found.role()).isEqualTo(data.role());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 토큰 조회 시 null을 반환한다")
+	void get_nonexistent_returnsNull() {
+		assertThat(refreshTokenRepository.getRefreshTokenData("nonexistent")).isNull();
+	}
+
+	@Test
+	@DisplayName("갱신 토큰 삭제 후 조회 시 null을 반환한다")
+	void delete_success() {
+		// given
+		String token = "delete-test-token";
+		refreshTokenRepository.saveRefreshToken(token, createTokenData());
+
+		// when
+		boolean deleted = refreshTokenRepository.deleteRefreshToken(token);
+
+		// then
+		assertThat(deleted).isTrue();
+		assertThat(refreshTokenRepository.getRefreshTokenData(token)).isNull();
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 토큰 삭제 시 false를 반환한다")
+	void delete_nonexistent_returnsFalse() {
+		assertThat(refreshTokenRepository.deleteRefreshToken("nonexistent")).isFalse();
+	}
+}

--- a/letzcollab-backend/src/test/java/xyz/letzcollab/backend/service/AuthServiceTest.java
+++ b/letzcollab-backend/src/test/java/xyz/letzcollab/backend/service/AuthServiceTest.java
@@ -10,10 +10,17 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import xyz.letzcollab.backend.dto.auth.LoginResponse;
+import xyz.letzcollab.backend.dto.auth.RefreshResponse;
+import xyz.letzcollab.backend.dto.auth.RefreshTokenData;
 import xyz.letzcollab.backend.dto.auth.SignupRequest;
 import xyz.letzcollab.backend.entity.User;
 import xyz.letzcollab.backend.entity.VerificationToken;
@@ -23,8 +30,10 @@ import xyz.letzcollab.backend.entity.vo.UserStatus;
 import xyz.letzcollab.backend.global.event.dto.EmailEvent;
 import xyz.letzcollab.backend.global.exception.CustomException;
 import xyz.letzcollab.backend.global.exception.ErrorCode;
+import xyz.letzcollab.backend.global.security.jwt.RefreshTokenProvider;
 import xyz.letzcollab.backend.repository.UserRepository;
 import xyz.letzcollab.backend.repository.VerificationTokenRepository;
+import xyz.letzcollab.backend.repository.redis.RefreshTokenRepository;
 
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
@@ -33,12 +42,14 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
 @DisplayName("AuthService 통합 테스트")
 @RecordApplicationEvents
+@Testcontainers
 class AuthServiceTest {
 
 	@Autowired
@@ -51,10 +62,25 @@ class AuthServiceTest {
 	private VerificationTokenRepository tokenRepository;
 
 	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@Autowired
+	private RefreshTokenProvider refreshTokenProvider;
+
+	@Container
+	private static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+	@Autowired
 	private PasswordEncoder passwordEncoder;
 
 	@Autowired
 	private ApplicationEvents events;
+
+	@DynamicPropertySource
+	private static void redisProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.redis.host", redis::getHost);
+		registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+	}
 
 	private SignupRequest createSignupRequest(String email) {
 		return new SignupRequest("홍길동", email, "Password1!", "010-1234-5678");
@@ -157,6 +183,9 @@ class AuthServiceTest {
 			assertThat(response.email()).isEqualTo("user@example.com");
 			assertThat(response.name()).isEqualTo("홍길동");
 			assertThat(response.accessToken()).isNotBlank();
+			assertThat(response.refreshToken()).isNotBlank();
+
+			assertThat(refreshTokenRepository.getRefreshTokenData(response.refreshToken())).isNotNull();
 		}
 
 		@Test
@@ -189,6 +218,91 @@ class AuthServiceTest {
 			// when & then
 			assertThatThrownBy(() -> authService.login("user@example.com", "Password1!"))
 					.isInstanceOf(BadCredentialsException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("JWT 재발급")
+	class Refresh {
+
+		@Test
+		@DisplayName("유효한 갱신 토큰으로 재발급 시 새로운 accessToken과 refreshToken이 반환되고 기존 토큰은 삭제된다")
+		void refresh_success() {
+			// given
+			User user = saveActiveUser("refresh@example.com");
+			String oldRefreshToken = refreshTokenProvider.createToken();
+			RefreshTokenData data = new RefreshTokenData(
+					user.getPublicId().toString(),
+					user.getEmail(),
+					user.getRole().getAuthority()
+			);
+			refreshTokenRepository.saveRefreshToken(oldRefreshToken, data);
+
+			// when
+			RefreshResponse response = authService.refresh(oldRefreshToken);
+
+			// then
+			assertThat(response.accessToken()).isNotNull();
+			assertThat(response.refreshToken()).isNotNull();
+			assertThat(response.refreshToken()).isNotEqualTo(oldRefreshToken);
+
+			assertThat(refreshTokenRepository.getRefreshTokenData(oldRefreshToken)).isNull();
+			assertThat(refreshTokenRepository.getRefreshTokenData(response.refreshToken())).isNotNull();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 갱신 토큰으로 재발급 시 INVALID_REFRESH_TOKEN 예외가 발생한다")
+		void refresh_invalidToken_throwsException() {
+			// given
+			String fakeToken = "invalid-token";
+
+			// when & then
+			assertThatThrownBy(() -> authService.refresh(fakeToken))
+					.isInstanceOf(CustomException.class)
+					.satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+							.isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN));
+		}
+
+		@Test
+		@DisplayName("null 갱신 토큰으로 재발급 시 INVALID_REFRESH_TOKEN 예외가 발생한다")
+		void refresh_nullToken_throwsException() {
+			assertThatThrownBy(() -> authService.refresh(null))
+					.isInstanceOf(CustomException.class)
+					.satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+							.isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN));
+		}
+	}
+
+	@Nested
+	@DisplayName("로그아웃")
+	class Logout {
+
+		@Test
+		@DisplayName("유효한 갱신 토큰으로 로그아웃 시 Redis에서 토큰이 삭제된다")
+		void logout_success() {
+			// given
+			User user = saveActiveUser("logout@example.com");
+			String refreshToken = refreshTokenProvider.createToken();
+			RefreshTokenData data = new RefreshTokenData(
+					user.getPublicId().toString(),
+					user.getEmail(),
+					user.getRole().getAuthority()
+			);
+			refreshTokenRepository.saveRefreshToken(refreshToken, data);
+
+			// when
+			authService.logout(refreshToken, user.getEmail());
+
+			// then
+			assertThat(refreshTokenRepository.getRefreshTokenData(refreshToken)).isNull();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 갱신 토큰으로 로그아웃 시 예외 없이 정상 처리된다")
+		void logout_invalidToken_noException() {
+			// when & then
+			assertThatCode(() -> authService.logout("nonexistent-token", "any@example.com"))
+					.doesNotThrowAnyException();
 		}
 	}
 

--- a/letzcollab-backend/src/test/resources/application-test.yml
+++ b/letzcollab-backend/src/test/resources/application-test.yml
@@ -1,6 +1,7 @@
 jwt:
   secret: "random+test+secret+key+with+more+than+45+characters"
-  access-validity-in-ms: 3600000
+  access-validity-in-ms: 900000
+  refresh-validity-in-days: 14
 
 
 spring:
@@ -18,6 +19,10 @@ spring:
         format_sql: true
         show_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 cookie:
   secure: false

--- a/letzcollab-frontend/src/api/axios.js
+++ b/letzcollab-frontend/src/api/axios.js
@@ -3,20 +3,69 @@ import axios from 'axios';
 // 매번 쿠키를 Cookie 헤더에 실어서 서버에 요청
 const api = axios.create({
   baseURL: import.meta.env.PROD ? '/api/v1' : 'http://localhost:8080/api/v1',
-  withCredentials: true
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json'
+  }
 })
+
+let isRefreshing = false;           // jwt 재발급 중복 호출 방지
+let failedQueue = [];               // jwt 재발급 중에 들어온 요청들 대기열
+
+const processQueue = (error) => {
+  failedQueue.forEach(({ resolve, reject }) => {
+    error ? reject(error) : resolve();
+  });
+  failedQueue = [];
+};
 
 api.interceptors.response.use(
   (res) => res,
-  (err) => {
+  async (err) => {
     const errorCode = err.response?.data?.errorCode;
-    if (errorCode === 'A003' || errorCode === 'A001') {
+    const originalRequest = err.config;
+
+    // A003: accessToken 만료 -> 재발급 시도
+    if ((errorCode === 'A003' || errorCode === 'A001') && !originalRequest._retry) {
+      originalRequest._retry = true;  // 무한 루프 방지
+
+      // 앞에 있던 요청이 이미 jwt를 재발급하고 있는 중이라면 지금 요청은 대기열에 추가되고,
+      // jwt 재발급이 성공하면 대기열에 있던 요청들이 다 resolve()됨 -> api(originalRequest) 요청 재시도
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        }).then(() => api(originalRequest));
+      }
+
+      // 가장 먼저 API를 호출했다가 토큰 만료 에러를 받은 요청이 토큰 재발급을 수행
+      isRefreshing = true;
+
+      try {
+        await api.post('/auth/refresh', null, {
+          headers: { 'X-Client-Type': 'web' }
+        });
+
+        processQueue(null);
+        return api(originalRequest);  // 원래 요청 재시도
+      } catch (refreshError) {
+        // JWT 재발급을 실패하면 로그인 페이지로
+        processQueue(refreshError);
         localStorage.removeItem('user');
         window.location.replace('/auth/login');
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    // A008: refreshToken도 만료 -> 로그인 페이지로
+    if (errorCode === 'A008') {
+      localStorage.removeItem('user');
+      window.location.replace('/auth/login');
     }
 
     return Promise.reject(err);
   }
-)
+);
 
 export default api;


### PR DESCRIPTION
## 📝 요약 (Summary)

JWT Access Token 단독 인증에서 갱신 토큰을 추가한 이중 토큰 인증 구조로 개선했습니다.
JWT Access Token 유효기간을 15분으로 단축하고, 갱신 토큰(14일)을 Redis에 저장하여 자동 갱신합니다.

- 이슈: #26 

## 🛠️ 작업 내용 (Details)

**인증 구조 변경**
- Access Token: 15분, HttpOnly 쿠키 (`path=/`)
- Refresh Token: 14일, HttpOnly 쿠키 (`path=/`), SecureRandom Base64 방식
- Refresh Token Rotation 적용 - 갱신할 때마다 기존 토큰 폐기 후 새 토큰 발급

**Redis**
- `RefreshTokenRepository` - `RT:{token}` 키로 `RefreshTokenData`(publicId, email, role) 직렬화한 JSON 값을 저장
- TTL도 추가하여 자동 만료로 별도 cleanup 불필요
- docker-compose 로컬/운영 환경에 redis 서비스 추가
- 운영 환경은 `--requirepass`로 비밀번호 설정, 포트 외부 미노출

**API 변경**
- `POST /v1/auth/login` - 기존 엔드포인트에서 Refresh Token도 응답에 같이 반환
- `POST /v1/auth/refresh` - 신규 엔드포인트, Refresh Token으로 Access Token, Refresh Token 재발급
- `POST /v1/auth/logout` - Redis에서 Refresh Token을 제거

**프론트엔드**
- axios 인터셉터에서 `A001`/`A003` 감지 시 `/auth/refresh` 자동 호출
- 동시 다중 요청 실패 시 `failedQueue`로 중복 JWT 재발급 방지
- JWT 재발급 실패 시 localStorage 초기화 후 로그인 페이지 이동

## 🔀 변경 유형 (Change Type)

- [x] 새로운 기능 추가 (non-breaking change which adds functionality)

## 🧪 테스트 방법 (Testing)

- `AuthServiceTest` - login 시 refreshToken 발급 및 Redis 저장 확인, refresh/logout 시나리오 테스트 완료
- `RefreshTokenRepositoryTest` - Testcontainers Redis로 저장/조회/삭제 단위 테스트
- 브라우저에서 Access Token 만료 후 자동 갱신 및 실패한 요청 재시도 확인
