### PR TITLE
[Feature] 워크스페이스 통계 조회 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,8 +549,12 @@ letzcollab/
 │       │   └── axios.js                 # Axios 인스턴스 (baseURL, credentials, JWT 만료 인터셉터)
 │       ├── components/
 │       │   ├── dashboard/
-│       │   │   ├── ProjectCard.jsx      # 프로젝트 카드 (상태, 리더, 기간, 공개여부 표시)
-│       │   │   └── TaskCard.jsx         # 업무 카드 (우선순위, 상태, 마감일 표시)
+│       │   │   ├── ProjectCard.jsx         # 프로젝트 카드 (상태, 리더, 기간, 공개여부 표시)
+│       │   │   ├── ProjectStatusList.jsx   # 프로젝트 상태별 현황
+│       │   │   ├── StatCard.jsx            # 워크스페이스 통계 요약 수치 카드
+│       │   │   ├── TaskDistributionBar.jsx # 업무 상태별 분포 바
+│       │   │   ├── WorkspaceStats.jsx      # 워크스페이스 통계 (프로젝트 현황, 업무 현황 등 표시)
+│       │   │   └── TaskCard.jsx            # 업무 카드 (우선순위, 상태, 마감일 표시)
 │       │   ├── project/
 │       │   │   ├── AddProjectMemberModal.jsx
 │       │   │   ├── CreateTaskModal.jsx
@@ -706,6 +710,7 @@ letzcollab/
             │   │   ├── WorkspaceResponse.java
             │   │   ├── WorkspaceDetailsResponse.java
             │   │   ├── WorkspaceInviteRequest.java
+            │   │   ├── WorkspaceStatsResponse.java
             │   │   ├── AcceptWorkspaceInvitationRequest.java
             │   │   ├── OwnerDto.java
             │   │   ├── MemberSummaryDto.java
@@ -717,6 +722,7 @@ letzcollab/
             │   │   ├── UpdateProjectRequest.java
             │   │   ├── ProjectResponse.java
             │   │   ├── ProjectDetailsResponse.java
+            │   │   ├── ProjectRawStatsDto.java
             │   │   ├── ProjectSearchCond.java
             │   │   ├── AddMemberRequest.java
             │   │   ├── UpdateMyselfRequest.java
@@ -729,6 +735,7 @@ letzcollab/
             │   │   ├── UpdateTaskRequest.java
             │   │   ├── TaskResponse.java
             │   │   ├── TaskDetailsResponse.java
+            │   │   ├── TaskRawStatsDto.java
             │   │   ├── TaskSearchCond.java
             │   │   ├── MyTaskResponse.java
             │   │   └── MyTaskSearchCond.java

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/controller/WorkspaceController.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/controller/WorkspaceController.java
@@ -8,10 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import xyz.letzcollab.backend.dto.workspace.CreateWorkspaceRequest;
-import xyz.letzcollab.backend.dto.workspace.UpdateWorkspaceRequest;
-import xyz.letzcollab.backend.dto.workspace.WorkspaceDetailsResponse;
-import xyz.letzcollab.backend.dto.workspace.WorkspaceResponse;
+import xyz.letzcollab.backend.dto.workspace.*;
 import xyz.letzcollab.backend.global.dto.ApiResponse;
 import xyz.letzcollab.backend.global.security.userdetails.CustomUserDetails;
 import xyz.letzcollab.backend.service.WorkspaceService;
@@ -96,5 +93,18 @@ public class WorkspaceController {
 	) {
 		workspaceService.deleteWorkspace(userDetails.getPublicId(), workspacePublicId);
 		return ResponseEntity.ok(ApiResponse.success("워크스페이스 삭제 성공!"));
+	}
+
+	@Operation(
+			summary = "워크스페이스 통계 조회",
+			description = "워크스페이스의 프로젝트/업무/멤버 통계를 조회합니다. (워크스페이스 멤버 전원 가능, 비공개 프로젝트도 통계 데이터에는 들어감)"
+	)
+	@GetMapping("/{workspacePublicId}/stats")
+	public ResponseEntity<ApiResponse<WorkspaceStatsResponse>> getWorkspaceStats(
+			@AuthenticationPrincipal CustomUserDetails userDetails,
+			@PathVariable UUID workspacePublicId
+	) {
+		WorkspaceStatsResponse response = workspaceService.getStats(userDetails.getPublicId(), workspacePublicId);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/project/ProjectRawStatsDto.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/project/ProjectRawStatsDto.java
@@ -1,4 +1,4 @@
-package xyz.letzcollab.backend.dto.workspace;
+package xyz.letzcollab.backend.dto.project;
 
 public record ProjectRawStatsDto(
 	long totalProjects,

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/task/TaskRawStatsDto.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/task/TaskRawStatsDto.java
@@ -1,4 +1,4 @@
-package xyz.letzcollab.backend.dto.workspace;
+package xyz.letzcollab.backend.dto.task;
 
 public record TaskRawStatsDto(
 	long totalTasks,

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/workspace/ProjectRawStatsDto.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/workspace/ProjectRawStatsDto.java
@@ -1,0 +1,11 @@
+package xyz.letzcollab.backend.dto.workspace;
+
+public record ProjectRawStatsDto(
+	long totalProjects,
+	long plannedProjects,
+	long activeProjects,
+	long onHoldProjects,
+	long completedProjects,
+	long archivedProjects
+) {
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/workspace/TaskRawStatsDto.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/workspace/TaskRawStatsDto.java
@@ -1,0 +1,12 @@
+package xyz.letzcollab.backend.dto.workspace;
+
+public record TaskRawStatsDto(
+	long totalTasks,
+	long todoTasks,
+	long inProgressTasks,
+	long inReviewTasks,
+	long doneTasks,
+	long cancelledTasks,
+	long overdueTasks
+) {
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/workspace/WorkspaceStatsResponse.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/workspace/WorkspaceStatsResponse.java
@@ -1,6 +1,8 @@
 package xyz.letzcollab.backend.dto.workspace;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import xyz.letzcollab.backend.dto.project.ProjectRawStatsDto;
+import xyz.letzcollab.backend.dto.task.TaskRawStatsDto;
 
 @Schema(description = "워크스페이스 통계 응답 DTO")
 public record WorkspaceStatsResponse(

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/workspace/WorkspaceStatsResponse.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/dto/workspace/WorkspaceStatsResponse.java
@@ -1,0 +1,69 @@
+package xyz.letzcollab.backend.dto.workspace;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "워크스페이스 통계 응답 DTO")
+public record WorkspaceStatsResponse(
+	@Schema(description = "프로젝트 통계")
+	ProjectStats projects,
+
+	@Schema(description = "업무 통계")
+	TaskStats tasks,
+
+	@Schema(description = "전체 멤버 수")
+	long totalMembers
+) {
+
+	@Schema(description = "프로젝트 통계")
+	public record ProjectStats(
+		@Schema(description = "전체 프로젝트 수") long total,
+		@Schema(description = "기획된 프로젝트 수") long planned,
+		@Schema(description = "진행 중인 프로젝트 수") long active,
+		@Schema(description = "일시 중단된 프로젝트 수") long onHold,
+		@Schema(description = "완료된 프로젝트 수") long completed,
+		@Schema(description = "보관된 프로젝트 수") long archived
+	) {}
+
+	@Schema(description = "업무 통계")
+	public record TaskStats(
+		@Schema(description = "전체 업무 수") long total,
+		@Schema(description = "시작 전 업무 수") long todo,
+		@Schema(description = "진행 중 업무 수") long inProgress,
+		@Schema(description = "검토 중 업무 수") long inReview,
+		@Schema(description = "완료된 업무 수") long done,
+		@Schema(description = "취소된 업무 수") long cancelled,
+		@Schema(description = "마감 초과 업무 수") long overdue,
+		@Schema(description = "업무 완료율 (0~100)", example = "72") int completionRate
+	) {}
+
+	public static WorkspaceStatsResponse from(ProjectRawStatsDto projectDto, TaskRawStatsDto taskDto, long totalMembers) {
+		int completionRate = 0;
+		long effective = taskDto.totalTasks() - taskDto.cancelledTasks();
+
+		if (effective > 0) {
+			completionRate = (int) Math.round(taskDto.doneTasks() * 100.0 / effective);
+		}
+
+		return new WorkspaceStatsResponse(
+			new ProjectStats(
+				projectDto.totalProjects(),
+				projectDto.plannedProjects(),
+				projectDto.activeProjects(),
+				projectDto.onHoldProjects(),
+				projectDto.completedProjects(),
+				projectDto.archivedProjects()
+			),
+			new TaskStats(
+				taskDto.totalTasks(),
+				taskDto.todoTasks(),
+				taskDto.inProgressTasks(),
+				taskDto.inReviewTasks(),
+				taskDto.doneTasks(),
+				taskDto.cancelledTasks(),
+				taskDto.overdueTasks(),
+				completionRate
+			),
+			totalMembers
+		);
+	}
+}

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/ProjectRepository.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/ProjectRepository.java
@@ -3,7 +3,7 @@ package xyz.letzcollab.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import xyz.letzcollab.backend.dto.workspace.ProjectRawStatsDto;
+import xyz.letzcollab.backend.dto.project.ProjectRawStatsDto;
 import xyz.letzcollab.backend.entity.Project;
 import xyz.letzcollab.backend.entity.Workspace;
 
@@ -30,7 +30,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
 
 	// 특정 워크스페이스의 프로젝트 통계를 실시간으로 집계
 	@Query("""
-			SELECT new xyz.letzcollab.backend.dto.workspace.ProjectRawStatsDto(
+			SELECT new xyz.letzcollab.backend.dto.project.ProjectRawStatsDto(
 				COUNT(DISTINCT p.id),
 				COALESCE(SUM(CASE WHEN p.status = 'PLANNED' THEN 1 ELSE 0 END), 0),
 				COALESCE(SUM(CASE WHEN p.status = 'ACTIVE' THEN 1 ELSE 0 END), 0),

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/ProjectRepository.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/ProjectRepository.java
@@ -3,9 +3,11 @@ package xyz.letzcollab.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import xyz.letzcollab.backend.dto.workspace.ProjectRawStatsDto;
 import xyz.letzcollab.backend.entity.Project;
 import xyz.letzcollab.backend.entity.Workspace;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,4 +27,19 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
 			"JOIN FETCH p.workspace " +
 			"WHERE p.publicId = :projectPublicId")
 	Optional<Project> findByPublicIdWithWorkspace(@Param("projectPublicId") UUID projectPublicId);
+
+	// 특정 워크스페이스의 프로젝트 통계를 실시간으로 집계
+	@Query("""
+			SELECT new xyz.letzcollab.backend.dto.workspace.ProjectRawStatsDto(
+				COUNT(DISTINCT p.id),
+				COALESCE(SUM(CASE WHEN p.status = 'PLANNED' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN p.status = 'ACTIVE' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN p.status = 'ON_HOLD' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN p.status = 'COMPLETED' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN p.status = 'ARCHIVED' THEN 1 ELSE 0 END), 0)
+			)
+			FROM Project p
+			WHERE p.workspace.publicId = :workspacePublicId
+			""")
+	ProjectRawStatsDto aggregateProjectStats(@Param("workspacePublicId") UUID workspacePublicId, @Param("today") LocalDate today);
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/TaskRepository.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/TaskRepository.java
@@ -3,7 +3,7 @@ package xyz.letzcollab.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import xyz.letzcollab.backend.dto.workspace.TaskRawStatsDto;
+import xyz.letzcollab.backend.dto.task.TaskRawStatsDto;
 import xyz.letzcollab.backend.entity.Task;
 
 import java.time.LocalDate;
@@ -63,7 +63,7 @@ public interface TaskRepository extends JpaRepository<Task, Long>, TaskRepositor
 
 	// 특정 워크스페이스의 업무 통계를 실시간으로 집계
 	@Query("""
-			SELECT new xyz.letzcollab.backend.dto.workspace.TaskRawStatsDto(
+			SELECT new xyz.letzcollab.backend.dto.task.TaskRawStatsDto(
 				COUNT(DISTINCT t.id),
 				COALESCE(SUM(CASE WHEN t.status = 'TODO' THEN 1 ELSE 0 END), 0),
 				COALESCE(SUM(CASE WHEN t.status = 'IN_PROGRESS' THEN 1 ELSE 0 END), 0),

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/TaskRepository.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/TaskRepository.java
@@ -3,6 +3,7 @@ package xyz.letzcollab.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import xyz.letzcollab.backend.dto.workspace.TaskRawStatsDto;
 import xyz.letzcollab.backend.entity.Task;
 
 import java.time.LocalDate;
@@ -59,4 +60,21 @@ public interface TaskRepository extends JpaRepository<Task, Long>, TaskRepositor
 			"WHERE t.dueDate = :dueDate " +
 			"AND t.status NOT IN ('DONE', 'CANCELLED')")
 	List<Task> findActiveTasksByDueDate(@Param("dueDate") LocalDate dueDate);
+
+	// 특정 워크스페이스의 업무 통계를 실시간으로 집계
+	@Query("""
+			SELECT new xyz.letzcollab.backend.dto.workspace.TaskRawStatsDto(
+				COUNT(DISTINCT t.id),
+				COALESCE(SUM(CASE WHEN t.status = 'TODO' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN t.status = 'IN_PROGRESS' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN t.status = 'IN_REVIEW' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN t.status = 'DONE' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN t.status = 'CANCELLED' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN t.dueDate < :today AND t.status NOT IN ('DONE', 'CANCELLED') THEN 1 ELSE 0 END), 0)
+			)
+			FROM Task t
+			JOIN Project p on t.project = p
+			WHERE p.workspace.publicId = :workspacePublicId
+			""")
+	TaskRawStatsDto aggregateTaskStats(@Param("workspacePublicId") UUID workspacePublicId, @Param("today") LocalDate today);
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/WorkspaceMemberRepository.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/repository/WorkspaceMemberRepository.java
@@ -78,4 +78,6 @@ public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember
 	boolean existsByWorkspacePublicIdAndUserPublicId(UUID workspacePublicId, UUID userPublicId);
 
 	boolean existsByWorkspaceAndUser(Workspace workspace, User user);
+
+	long countByWorkspacePublicId(UUID workspacePublicId);
 }

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/WorkspaceService.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/WorkspaceService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import xyz.letzcollab.backend.dto.project.ProjectRawStatsDto;
+import xyz.letzcollab.backend.dto.task.TaskRawStatsDto;
 import xyz.letzcollab.backend.dto.workspace.*;
 import xyz.letzcollab.backend.entity.User;
 import xyz.letzcollab.backend.entity.Workspace;

--- a/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/WorkspaceService.java
+++ b/letzcollab-backend/src/main/java/xyz/letzcollab/backend/service/WorkspaceService.java
@@ -4,16 +4,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import xyz.letzcollab.backend.dto.workspace.WorkspaceDetailsResponse;
-import xyz.letzcollab.backend.dto.workspace.WorkspaceResponse;
+import xyz.letzcollab.backend.dto.workspace.*;
 import xyz.letzcollab.backend.entity.User;
 import xyz.letzcollab.backend.entity.Workspace;
 import xyz.letzcollab.backend.entity.WorkspaceMember;
 import xyz.letzcollab.backend.global.exception.CustomException;
-import xyz.letzcollab.backend.repository.UserRepository;
-import xyz.letzcollab.backend.repository.WorkspaceMemberRepository;
-import xyz.letzcollab.backend.repository.WorkspaceRepository;
+import xyz.letzcollab.backend.repository.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,6 +31,8 @@ public class WorkspaceService {
 	private final WorkspaceRepository workspaceRepository;
 	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final UserRepository userRepository;
+	private final ProjectRepository projectRepository;
+	private final TaskRepository taskRepository;
 
 	/**
 	 * (워크스페이스 이름, 소유자 ID)에 복합 unique 제약조건이 있음
@@ -92,6 +92,14 @@ public class WorkspaceService {
 		Workspace foundWorkspace = getWorkspaceAndCheckOwner(userPublicId, workspacePublicId);
 		foundWorkspace.softDelete();
 		log.info("워크스페이스 삭제 - workspaceId={}, ownerUserId={}", workspacePublicId, userPublicId);
+	}
+
+	public WorkspaceStatsResponse getStats(UUID userPublicId, UUID workspacePublicId) {
+		validateMemberAndWorkspaceExistence(userPublicId, workspacePublicId);
+		ProjectRawStatsDto projectStats = projectRepository.aggregateProjectStats(workspacePublicId, LocalDate.now());
+		TaskRawStatsDto taskStats = taskRepository.aggregateTaskStats(workspacePublicId, LocalDate.now());
+		long count = workspaceMemberRepository.countByWorkspacePublicId(workspacePublicId);
+		return WorkspaceStatsResponse.from(projectStats, taskStats, count);
 	}
 
 

--- a/letzcollab-backend/src/test/http/workspace.http
+++ b/letzcollab-backend/src/test/http/workspace.http
@@ -24,3 +24,7 @@ Content-Type: application/json
 {
   "newName": "수정된 워크스페이스명"
 }
+
+### 05. 워크스페이스 통계 조회
+GET {{baseUrl}}/v1/workspaces/{{workspacePublicId}}/stats
+Authorization: Bearer {{token}}

--- a/letzcollab-backend/src/test/java/xyz/letzcollab/backend/service/WorkspaceServiceTest.java
+++ b/letzcollab-backend/src/test/java/xyz/letzcollab/backend/service/WorkspaceServiceTest.java
@@ -12,15 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 import xyz.letzcollab.backend.TestAuditConfig;
 import xyz.letzcollab.backend.dto.workspace.WorkspaceDetailsResponse;
 import xyz.letzcollab.backend.dto.workspace.WorkspaceResponse;
-import xyz.letzcollab.backend.entity.User;
-import xyz.letzcollab.backend.entity.Workspace;
-import xyz.letzcollab.backend.entity.WorkspaceMember;
+import xyz.letzcollab.backend.dto.workspace.WorkspaceStatsResponse;
+import xyz.letzcollab.backend.entity.*;
+import xyz.letzcollab.backend.entity.vo.ProjectStatus;
+import xyz.letzcollab.backend.entity.vo.TaskPriority;
 import xyz.letzcollab.backend.entity.vo.WorkspaceRole;
 import xyz.letzcollab.backend.global.exception.CustomException;
-import xyz.letzcollab.backend.repository.UserRepository;
-import xyz.letzcollab.backend.repository.WorkspaceMemberRepository;
-import xyz.letzcollab.backend.repository.WorkspaceRepository;
+import xyz.letzcollab.backend.repository.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -44,6 +44,12 @@ class WorkspaceServiceTest {
 
 	@Autowired
 	WorkspaceMemberRepository workspaceMemberRepository;
+
+	@Autowired
+	ProjectRepository projectRepository;
+
+	@Autowired
+	TaskRepository taskRepository;
 
 	private User owner;
 	private User otherUser;
@@ -273,6 +279,58 @@ class WorkspaceServiceTest {
 					.isInstanceOf(CustomException.class)
 					.extracting(e -> ((CustomException) e).getErrorCode())
 					.isEqualTo(WORKSPACE_NOT_FOUND_OR_ACCESS_DENIED);
+		}
+	}
+
+	@Nested
+	@DisplayName("워크스페이스 통계 조회")
+	class GetWorkspaceStats {
+		@Test
+		@DisplayName("워크스페이스에 멤버 1명, 프로젝트 2개, 각 프로젝트에 업무 3개 있을 때 올바른 통계를 반환한다")
+		void getsCorrectStats() {
+			// given
+			Workspace workspace = Workspace.createWorkspace("우아한동네 개발팀", owner, "CTO");
+			workspaceRepository.save(workspace);
+			workspaceMemberRepository.save(WorkspaceMember.createGeneralMember(otherUser, workspace, "디자이너"));
+
+			for (int i = 0; i < 2; i++) {
+				Project project = Project.createProject(
+						workspace, "프로젝트" + i, "", ProjectStatus.ACTIVE, LocalDate.now(),
+						LocalDate.now().plusDays(i), false, owner, "CTO"
+				);
+				projectRepository.save(project);
+
+				for (int j = 0; j < 3; j++) {
+					// TODO 상태인 업무를 3개 생성
+					Task task = Task.createTask(
+							project, "업무" + i, "", otherUser, TaskPriority.values()[i], null,
+							owner, LocalDate.now().plusDays(30)
+					);
+					taskRepository.save(task);
+				}
+			}
+
+			// when
+			WorkspaceStatsResponse stats = workspaceService.getStats(owner.getPublicId(), workspace.getPublicId());
+
+			// then
+			assertThat(stats.projects().total()).isEqualTo(2);
+			assertThat(stats.projects().planned()).isEqualTo(0);
+			assertThat(stats.projects().active()).isEqualTo(2);
+			assertThat(stats.projects().onHold()).isEqualTo(0);
+			assertThat(stats.projects().completed()).isEqualTo(0);
+			assertThat(stats.projects().archived()).isEqualTo(0);
+
+			assertThat(stats.tasks().total()).isEqualTo(6);
+			assertThat(stats.tasks().todo()).isEqualTo(6);
+			assertThat(stats.tasks().inProgress()).isEqualTo(0);
+			assertThat(stats.tasks().inReview()).isEqualTo(0);
+			assertThat(stats.tasks().done()).isEqualTo(0);
+			assertThat(stats.tasks().cancelled()).isEqualTo(0);
+			assertThat(stats.tasks().overdue()).isEqualTo(0);
+			assertThat(stats.tasks().completionRate()).isEqualTo(0);
+
+			assertThat(stats.totalMembers()).isEqualTo(2);
 		}
 	}
 

--- a/letzcollab-frontend/src/components/dashboard/ProjectCard.jsx
+++ b/letzcollab-frontend/src/components/dashboard/ProjectCard.jsx
@@ -8,7 +8,7 @@ export default function ProjectCard({ project }) {
   const status = PROJECT_STATUS_CONFIG[project.status] ?? { color: 'default', label: project.status };
 
   return (
-    <Card size="small" hoverable styles={{ body: { padding: '14px 16px' } }}>
+    <Card size="small" variant={"borderless"} hoverable styles={{ body: { padding: '14px 16px' } }}>
       <Flex vertical gap={8}>
 
         <Flex justify="space-between" align="flex-start" gap={8}>

--- a/letzcollab-frontend/src/components/dashboard/ProjectStatusList.jsx
+++ b/letzcollab-frontend/src/components/dashboard/ProjectStatusList.jsx
@@ -1,0 +1,84 @@
+import { Empty, Flex, Progress, Typography } from 'antd';
+import { PROJECT_STATUS_CONFIG } from '../../constants/projectStatus.js';
+
+const { Text } = Typography;
+
+export default function ProjectStatusList({ stats }) {
+  const total = stats.total ?? 0;
+  if (total === 0) return <Empty description="프로젝트가 없습니다" />;
+
+  const rows = Object.values(PROJECT_STATUS_CONFIG)
+    .map(cfg => ({ ...cfg, value: stats[cfg.dtoKey] ?? 0 }))
+    .sort((a, b) => a.order - b.order);
+
+  return (
+    <Flex vertical gap={0}>
+      {rows.map(({ dtoKey, chartColor, label, value }, i) => {
+        const pct = Math.round((value / total) * 100);
+        return (
+          <Flex
+            key={dtoKey}
+            align="center"
+            justify="space-between"
+            style={{
+              padding: '12px 0',
+              borderBottom:
+                i < rows.length - 1
+                  ? '1px solid #f0f0f0'
+                  : 'none',
+            }}
+          >
+            {/* 상태명 */}
+            <Flex align="center" gap={8}>
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: chartColor,
+                  flexShrink: 0,
+                }}
+              />
+
+              <Text style={{ fontSize: 13 }}>
+                {label}
+              </Text>
+            </Flex>
+
+            {/* 퍼센트 + 개수 */}
+            <Flex
+              align="center"
+              gap={10}
+              style={{
+                minWidth: 140,
+              }}
+            >
+              <Progress
+                percent={pct}
+                showInfo={false}
+                size="small"
+                strokeColor={chartColor}
+                railColor="#f0f0f0"
+                style={{
+                  margin: 0,
+                  flex: 1,
+                }}
+              />
+
+              <Text
+                strong
+                style={{
+                  fontSize: 13,
+                  minWidth: 18,
+                  textAlign: 'right',
+                }}
+              >
+                {value}
+              </Text>
+            </Flex>
+          </Flex>
+        );
+      })}
+    </Flex>
+  );
+}

--- a/letzcollab-frontend/src/components/dashboard/StatCard.jsx
+++ b/letzcollab-frontend/src/components/dashboard/StatCard.jsx
@@ -1,0 +1,63 @@
+import { Card, Flex, Statistic, Typography } from 'antd';
+
+const { Text } = Typography;
+
+export default function StatCard({ icon, value, label, color = '#1677ff', suffix, }) {
+  return (
+    <Card
+      variant={"borderless"}
+      style={{ height: '100%' }}
+      styles={{
+        body: {
+          padding: 16,
+        },
+      }}
+    >
+      <Flex align="center" gap={12}>
+        {/* 아이콘 */}
+        <Flex
+          align="center"
+          justify="center"
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 10,
+            background: `${color}15`,
+            fontSize: 18,
+            color,
+            flexShrink: 0,
+          }}
+        >
+          {icon}
+        </Flex>
+
+        {/* 텍스트 */}
+        <Flex vertical gap={0}>
+          <Statistic
+            value={value}
+            suffix={suffix}
+            styles={{
+              content: {
+                fontSize: 20,
+                fontWeight: 700,
+                lineHeight: 1.1,
+                color: '#262626',
+                marginBottom: 4,
+              },
+            }}
+          />
+
+          <Text
+            type="secondary"
+            style={{
+              fontSize: 12,
+              lineHeight: 1.2,
+            }}
+          >
+            {label}
+          </Text>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/letzcollab-frontend/src/components/dashboard/TaskCard.jsx
+++ b/letzcollab-frontend/src/components/dashboard/TaskCard.jsx
@@ -11,7 +11,7 @@ export default function TaskCard({ task }) {
   const due = formatDueDate(task.dueDate);
 
   return (
-    <Card size="small" hoverable styles={{ body: { padding: '12px 16px' } }}>
+    <Card size="small" variant={"borderless"} hoverable styles={{ body: { padding: '12px 16px' } }}>
       <Flex vertical gap={6}>
 
         <Flex justify="space-between" align="center">

--- a/letzcollab-frontend/src/components/dashboard/TaskDistributionBar.jsx
+++ b/letzcollab-frontend/src/components/dashboard/TaskDistributionBar.jsx
@@ -1,0 +1,39 @@
+import { Flex, Typography } from 'antd';
+import { STATUS_CONFIG } from '../../constants/taskStatus.js';
+
+const { Text } = Typography;
+
+export default function TaskDistributionBar({ stats }) {
+  const segments = Object.values(STATUS_CONFIG)
+    .map(cfg => ({ ...cfg, value: stats[cfg.dtoKey] ?? 0 }))
+    .filter(s => s.value > 0)
+    .sort((a, b) => a.order - b.order);
+
+  const total = segments.reduce((sum, s) => sum + s.value, 0);
+  if (total === 0) return null;
+
+  return (
+    <Flex vertical gap={8}>
+      <Flex style={{ height: 8, borderRadius: 4, overflow: 'hidden', background: '#f0f0f0' }}>
+        {segments.map((seg, i) => (
+          <div
+            key={i}
+            style={{
+              width: `${(seg.value / total) * 100}%`,
+              background: seg.chartColor,
+              transition: 'width 0.4s ease',
+            }}
+          />
+        ))}
+      </Flex>
+      <Flex gap={12} wrap="wrap">
+        {segments.map((seg, i) => (
+          <Flex key={i} align="center" gap={4}>
+            <div style={{ width: 8, height: 8, borderRadius: 2, background: seg.chartColor, flexShrink: 0 }} />
+            <Text type="secondary" style={{ fontSize: 11 }}>{seg.label} {seg.value}</Text>
+          </Flex>
+        ))}
+      </Flex>
+    </Flex>
+  );
+}

--- a/letzcollab-frontend/src/components/dashboard/WorkspaceStats.jsx
+++ b/letzcollab-frontend/src/components/dashboard/WorkspaceStats.jsx
@@ -1,0 +1,152 @@
+import { Card, Col, Flex, Progress, Row, Skeleton, Typography } from 'antd';
+import { AlertOutlined, CheckCircleOutlined, FolderOutlined, TeamOutlined, } from '@ant-design/icons';
+import StatCard from './StatCard.jsx';
+import TaskDistributionBar from './TaskDistributionBar.jsx';
+import ProjectStatusList from './ProjectStatusList.jsx';
+
+const { Text } = Typography;
+
+export default function WorkspaceStats({ data, isLoading }) {
+  if (isLoading) {
+    return (
+      <Row gutter={[16, 16]}>
+        {[1, 2, 3, 4].map(i => (
+          <Col key={i} xs={12} sm={12} md={6}>
+            <Skeleton active paragraph={{ rows: 1 }} />
+          </Col>
+        ))}
+      </Row>
+    );
+  }
+
+  if (!data) return null;
+
+  const { tasks: t = {}, projects: p = {}, totalMembers = 0 } = data;
+
+  return (
+    <Flex vertical gap={16}>
+
+      {/* 상단 요약 카드 */}
+      <Row gutter={[16, 16]}>
+        <Col xs={12} sm={12} md={6}>
+          <StatCard
+            icon={<FolderOutlined />}
+            value={p.active ?? 0}
+            label="진행 중인 프로젝트"
+            color="#1677ff"
+          />
+        </Col>
+
+        <Col xs={12} sm={12} md={6}>
+          <StatCard
+            icon={<TeamOutlined />}
+            value={totalMembers}
+            label="전체 멤버"
+            color="#722ed1"
+          />
+        </Col>
+
+        <Col xs={12} sm={12} md={6}>
+          <StatCard
+            icon={<CheckCircleOutlined />}
+            value={t.completionRate ?? 0}
+            suffix="%"
+            label="업무 완료율"
+            color="#13c2c2"
+          />
+        </Col>
+
+        <Col xs={12} sm={12} md={6}>
+          <StatCard
+            icon={<AlertOutlined />}
+            value={t.overdue ?? 0}
+            label="마감 초과 업무"
+            color={t.overdue > 0 ? '#ff4d4f' : '#8c8c8c'}
+          />
+        </Col>
+      </Row>
+
+      {/* 하단 현황 카드 */}
+      <Row gutter={[16, 16]}>
+
+        {/* 업무 현황 */}
+        <Col xs={24} md={12}>
+          <Card
+            title="업무 현황"
+            variant={"borderless"}
+            extra={
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                전체 {t.total ?? 0}개
+              </Text>
+            }
+            style={{ height: '100%' }}
+            styles={{
+              header: {
+                minHeight: 52,
+              },
+              body: {
+                paddingTop: 16,
+              },
+            }}
+          >
+            <Flex vertical gap={20}>
+
+              {/* 완료율 */}
+              <Flex vertical gap={6}>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  완료율
+                </Text>
+
+                <Progress
+                  percent={t.completionRate ?? 0}
+                  strokeColor="#13c2c2"
+                  railColor="#f0f0f0"
+                />
+              </Flex>
+
+              {/* 상태 분포 */}
+              <Flex vertical gap={6}>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  상태별 분포
+                </Text>
+
+                <TaskDistributionBar
+                  stats={{
+                    todo: t.todo ?? 0,
+                    inProgress: t.inProgress ?? 0,
+                    inReview: t.inReview ?? 0,
+                    done: t.done ?? 0,
+                    cancelled: t.cancelled ?? 0,
+                  }}
+                />
+              </Flex>
+
+            </Flex>
+          </Card>
+        </Col>
+
+        {/* 프로젝트 현황 */}
+        <Col xs={24} md={12}>
+          <Card
+            title="프로젝트 현황"
+            variant={"borderless"}
+            extra={
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                전체 {p.total ?? 0}개
+              </Text>
+            }
+            style={{ height: '100%' }}
+            styles={{
+              header: {
+                minHeight: 52,
+              },
+            }}
+          >
+            <ProjectStatusList stats={p} />
+          </Card>
+        </Col>
+
+      </Row>
+    </Flex>
+  );
+}

--- a/letzcollab-frontend/src/constants/projectStatus.js
+++ b/letzcollab-frontend/src/constants/projectStatus.js
@@ -1,7 +1,7 @@
 export const PROJECT_STATUS_CONFIG = {
-  PLANNED: { color: 'default', label: '기획됨' },
-  ACTIVE: { color: 'processing', label: '진행 중' },
-  ON_HOLD: { color: 'warning', label: '일시 중단' },
-  COMPLETED: { color: 'success', label: '완료' },
-  ARCHIVED: { color: '#8c8c8c', label: '보관됨' }
+  PLANNED: { color: 'default', chartColor: '#7F77DD', label: '기획됨', order: 3, dtoKey: 'planned' },
+  ACTIVE: { color: 'processing', chartColor: '#1D9E75', label: '진행 중', order: 1, dtoKey: 'active' },
+  ON_HOLD: { color: 'warning', chartColor: '#EF9F27', label: '일시 중단', order: 4, dtoKey: 'onHold' },
+  COMPLETED: { color: 'success', chartColor: '#639922', label: '완료', order: 2, dtoKey: 'completed' },
+  ARCHIVED: { color: '#8c8c8c', chartColor: '#888780', label: '보관됨', order: 5, dtoKey: 'archived' },
 };

--- a/letzcollab-frontend/src/constants/taskStatus.js
+++ b/letzcollab-frontend/src/constants/taskStatus.js
@@ -1,9 +1,9 @@
 export const STATUS_CONFIG = {
-  TODO: { color: 'default', label: '할 일' },
-  IN_PROGRESS: { color: 'processing', label: '진행 중' },
-  IN_REVIEW: { color: 'warning', label: '검토 중' },
-  DONE: { color: 'success', label: '완료' },
-  CANCELLED: { color: 'error', label: '취소됨' },
+  TODO: { color: 'default', chartColor: '#f0f0f0', label: '시작 전', order: 4, dtoKey: 'todo' },
+  IN_PROGRESS: { color: 'processing', chartColor: '#1677ff', label: '진행 중', order: 2, dtoKey: 'inProgress' },
+  IN_REVIEW: { color: 'warning', chartColor: '#faad14', label: '검토 중', order: 3, dtoKey: 'inReview' },
+  DONE: { color: 'success', chartColor: '#52c41a', label: '완료', order: 1, dtoKey: 'done' },
+  CANCELLED: { color: 'error', chartColor: '#ff4d4f', label: '취소됨', order: 5, dtoKey: 'cancelled' },
 };
 
 export const PRIORITY_CONFIG = {

--- a/letzcollab-frontend/src/pages/Dashboard.jsx
+++ b/letzcollab-frontend/src/pages/Dashboard.jsx
@@ -6,9 +6,12 @@ import api from '../api/axios.js';
 import ProjectCard from '../components/dashboard/ProjectCard.jsx';
 import TaskCard from '../components/dashboard/TaskCard.jsx';
 import { useWorkspace } from "../contexts/WorkspaceContext.jsx";
+import WorkspaceStats from "../components/dashboard/WorkspaceStats.jsx";
 
 const { Title, Text } = Typography;
-const POLLING_INTERVAL = 1000 * 60;
+const PROJECT_POLLING_INTERVAL = 1000 * 60 * 3;
+const TASK_POLLING_INTERVAL = 1000 * 60;
+const STATS_POLLING_INTERVAL = 1000 * 60 * 5;
 
 export default function Dashboard() {
   const user = JSON.parse(localStorage.getItem('user'));
@@ -22,7 +25,7 @@ export default function Dashboard() {
       return res.data.data;
     },
     enabled: !!workspaceId,
-    refetchInterval: POLLING_INTERVAL,
+    refetchInterval: PROJECT_POLLING_INTERVAL,
     refetchIntervalInBackground: false
   });
 
@@ -33,8 +36,19 @@ export default function Dashboard() {
       return res.data.data;
     },
     enabled: !!workspaceId,
-    refetchInterval: POLLING_INTERVAL,
+    refetchInterval: TASK_POLLING_INTERVAL,
     refetchIntervalInBackground: false
+  });
+
+  const { data: statsData, isLoading: statsLoading } = useQuery({
+    queryKey: ['workspaceStats', workspaceId],
+    queryFn: async () => {
+      const res = await api.get(`/workspaces/${workspaceId}/stats`);
+      return res.data.data;
+    },
+    enabled: !!workspaceId,
+    refetchInterval: STATS_POLLING_INTERVAL,
+    refetchIntervalInBackground: false,
   });
 
   const projects = projectsData?.content ?? [];
@@ -54,85 +68,94 @@ export default function Dashboard() {
       {!workspaceId ? (
         <Flex justify="center" align="center" style={{ minHeight: 320 }}>
           <Empty
-            image={<ProjectOutlined style={{ fontSize: 48, color: '#d9d9d9' }} />}
+            image={<ProjectOutlined style={{ fontSize: 48, color: '#d9d9d9' }}/>}
             styles={{ image: { height: 60 } }}
             description={<Text type="secondary">사이드바에서 워크스페이스를 선택하면 대시보드가 표시됩니다</Text>}
           />
         </Flex>
       ) : (
-        <Row gutter={[24, 24]}>
+        <Flex vertical gap={24}>
+          {/* 워크스페이스 현황 */}
+          <Flex vertical gap={16}>
+            <Text strong style={{ fontSize: 15 }}>워크스페이스 현황</Text>
+            <WorkspaceStats data={statsData} isLoading={statsLoading} />
+          </Flex>
 
-          <Col xs={24} lg={13}>
-            <Flex vertical gap={12}>
-              <Flex justify="space-between" align="center">
-                <Text strong style={{ fontSize: 15 }}>프로젝트</Text>
-                {/* totalElements로 전체 개수 표시, 20개 초과 시 "최근 20개" 안내 */}
-                {projectsData && (
-                  <Text type="secondary" style={{ fontSize: 12 }}>
-                    총 {totalProjects}개
-                    {totalProjects > 20 && ' (최근 20개)'}
-                  </Text>
+          {/* 프로젝트 목록 + 내 업무 */}
+          <Row gutter={[16, 16]}>
+
+            <Col xs={24} lg={12}>
+              <Flex vertical gap={12}>
+                <Flex justify="space-between" align="center">
+                  <Text strong style={{ fontSize: 15 }}>프로젝트</Text>
+                  {/* totalElements로 전체 개수 표시, 20개 초과 시 "최근 20개" 안내 */}
+                  {projectsData && (
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      총 {totalProjects}개
+                      {totalProjects > 20 && ' (최근 20개)'}
+                    </Text>
+                  )}
+                </Flex>
+                {projectsLoading ? (
+                  <Flex vertical gap={8}>
+                    {[1, 2, 3].map(i => <Skeleton key={i} active paragraph={{ rows: 2 }}/>)}
+                  </Flex>
+                ) : !projects.length ? (
+                  <Empty description="프로젝트가 없습니다"/>
+                ) : (
+                  <Flex vertical gap={8}>
+                    {projects.map(p => (
+                      <div
+                        key={p.publicId}
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => nav(`/workspaces/${workspaceId}/projects/${p.publicId}`)}
+                      >
+                        <ProjectCard project={p}/>
+                      </div>
+                    ))}
+                  </Flex>
                 )}
               </Flex>
-              {projectsLoading ? (
-                <Flex vertical gap={8}>
-                  {[1, 2, 3].map(i => <Skeleton key={i} active paragraph={{ rows: 2 }}/>)}
-                </Flex>
-              ) : !projects.length ? (
-                <Empty description="프로젝트가 없습니다"/>
-              ) : (
-                <Flex vertical gap={8}>
-                  {projects.map(p => (
-                    <div
-                      key={p.publicId}
-                      style={{ cursor: 'pointer' }}
-                      onClick={() => nav(`/workspaces/${workspaceId}/projects/${p.publicId}`)}
-                    >
-                      <ProjectCard project={p}/>
-                    </div>
-                  ))}
-                </Flex>
-              )}
-            </Flex>
-          </Col>
+            </Col>
 
-          <Col xs={24} lg={11}>
-            <Flex vertical gap={12}>
-              <Flex justify="space-between" align="center">
-                <Text strong style={{ fontSize: 15 }}>내 업무</Text>
-                {myTasksData && (
-                  <Text type="secondary" style={{ fontSize: 12 }}>
-                    총 {totalMyTasks}개
-                    {totalMyTasks > 20 && ' (마감 임박순 20개)'}
-                  </Text>
+            <Col xs={24} lg={12}>
+              <Flex vertical gap={12}>
+                <Flex justify="space-between" align="center">
+                  <Text strong style={{ fontSize: 15 }}>내 업무</Text>
+                  {myTasksData && (
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      총 {totalMyTasks}개
+                      {totalMyTasks > 20 && ' (마감 임박순 20개)'}
+                    </Text>
+                  )}
+                </Flex>
+                {tasksLoading ? (
+                  <Flex vertical gap={8}>
+                    {[1, 2, 3].map(i => <Skeleton key={i} active paragraph={{ rows: 2 }}/>)}
+                  </Flex>
+                ) : !myTasks.length ? (
+                  <Empty description="담당 업무가 없습니다"/>
+                ) : (
+                  <Flex vertical gap={8}>
+                    {myTasks.map(t => (
+                      <div
+                        key={t.publicId}
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => t.projectPublicId
+                          ? nav(`/projects/${t.projectPublicId}/tasks/${t.publicId}`)
+                          : undefined
+                        }
+                      >
+                        <TaskCard task={t}/>
+                      </div>
+                    ))}
+                  </Flex>
                 )}
               </Flex>
-              {tasksLoading ? (
-                <Flex vertical gap={8}>
-                  {[1, 2, 3].map(i => <Skeleton key={i} active paragraph={{ rows: 2 }}/>)}
-                </Flex>
-              ) : !myTasks.length ? (
-                <Empty description="담당 업무가 없습니다"/>
-              ) : (
-                <Flex vertical gap={8}>
-                  {myTasks.map(t => (
-                    <div
-                      key={t.publicId}
-                      style={{ cursor: 'pointer' }}
-                      onClick={() => t.projectPublicId
-                        ? nav(`/projects/${t.projectPublicId}/tasks/${t.publicId}`)
-                        : undefined
-                      }
-                    >
-                      <TaskCard task={t}/>
-                    </div>
-                  ))}
-                </Flex>
-              )}
-            </Flex>
-          </Col>
+            </Col>
 
-        </Row>
+          </Row>
+        </Flex>
       )}
     </Flex>
   );


### PR DESCRIPTION
## 📝 요약 (Summary)

워크스페이스 대시보드에서 프로젝트·업무·멤버 현황을 조회할 수 있는 통계 API를 구현하고,
대시보드에 워크스페이스 현황 섹션을 추가했습니다.

`GET /v1/workspaces/{workspacePublicId}/stats`

- 이슈 #28

---

## 🛠️ 작업 내용 (Details)

### Backend

**`ProjectRawStatsDto` / `TaskRawStatsDto`**
- `aggregateProjectStats()` / `aggregateTaskStats()` JPQL 집계 결과를 받는 내부 전용 DTO

**`ProjectRepository.aggregateProjectStats()`**
- 워크스페이스의 `publicId`에 해당하는 모든 프로젝트에 대해서 총 프로젝트 수와 상태별(PLANNED, ACTIVE 등) 프로젝트 수를 집계하는 `@Query` 추가

**`TaskRepository.aggregateTaskStats()`**
- 워크스페이스의 `publicId`에 해당하는 모든 프로젝트에 대해서 업무를 JOIN하여 총 업무 수와 상태별(TODO, IN_PROGRESS 등) 업무 수, 마감 초과 업무 수를 집계하는 `@Query` 추가

**`WorkspaceMemberRepository.countByWorkspacePublicId()`**
- 메서드 이름 기반 쿼리로 멤버 수 별도 조회

**`WorkspaceStatsResponse`**
- `ProjectStats`, `TaskStats` 중첩 레코드로 응답 구조화
- 완료율(`completionRate`)은 DB 집계가 아닌 Java에서 계산: `DONE / (전체 - CANCELLED) × 100`
- `from(ProjectRawStatsDto pDto, TaskRawStatsDto tDto, long totalMembers)` 팩토리 메서드로 세 개의 쿼리 결과를 조립

**`WorkspaceService.getStats()`**
- 워크스페이스 멤버 여부 검증 후 `aggregateProjectStats()` + `aggregateTaskStats()` + `countByWorkspacePublicId()` 세 개의 쿼리 실행
- 쿼리 결과 값을 인자로 WorkspaceStatsResponse.from()을 호출하여 응답을 반환

**`WorkspaceController`**
- `GET /{workspacePublicId}/stats` 엔드포인트 추가

**`WorkspaceServiceTest`**
- 기존 통합 테스트 클래스에 워크스페이스 통계 조회 엔드포인트 테스트(`getsCorrectStats()`) 추가

---

### Frontend

**`constants/projectStatus.js`, `constants/taskStatus.js`**
- `chartColor`: 분포 바 및 리스트에서 사용할 차트용 색상 추가
- `order`: 분포 바, 리스트 표시 순서 정의
- `dtoKey`: API 응답의 camelCase 키와 상수를 매핑

**`StatCard`**
- 진행 중 프로젝트 수, 전체 멤버 수, 업무 완료율, 마감 초과 업무 수를 표시하는 요약 카드

**`TaskDistributionBar`**
- `STATUS_CONFIG`의 `dtoKey`, `chartColor`, `order`를 활용해 업무 상태 누적 분포 바 렌더링
- `Object.values(STATUS_CONFIG).sort((a, b) => a.order - b.order)`로 하드코딩 배열 없이 순회

**`ProjectStatusList`**
- `PROJECT_STATUS_CONFIG`를 동일하게 활용해 프로젝트 상태별 수치와 미니 바를 테이블 형태로 렌더링

**`WorkspaceStats`**
- 위 컴포넌트들을 묶어 로딩/null 처리를 담당하는 통계 섹션 컴포넌트
- 반응형 적용
  - 요약 수치 카드: 모바일 2열 → md 이상 4열
  - 업무, 프로젝트 현황 카드: 모바일 단열 → md 이상 2열

**`Dashboard.jsx`**
- 워크스페이스 현황 섹션 추가, `useQuery`로 `/workspaces/{id}/stats` 호출 (polling 5분)

---

## 🔀 변경 유형 (Change Type)

- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)

---

## 🧪 테스트 방법 (Testing)
- 백엔드 엔드포인트 테스트: WorkspaceServiceTest 통합 테스트 실행
- 프론트엔드 통합 테스트:

**테스트 시나리오**
1. 워크스페이스 멤버 계정으로 로그인
2. 대시보드 접속 후 워크스페이스 현황 섹션(요약 카드 4개, 업무 분포 바, 프로젝트 현황 리스트) 정상 렌더링 확인
3. `GET /v1/workspaces/{workspacePublicId}/stats` 직접 호출 후 프로젝트 상태별 수, 업무 상태별 수, 멤버 수, 완료율 정확도 확인
4. 워크스페이스 비멤버 계정으로 동일 API 요청 시 `403` 반환 확인
5. 모바일 뷰포트에서 반응형 레이아웃 확인